### PR TITLE
Add UpdateActivity endpoint with tests

### DIFF
--- a/GirafRest.Test/Controllers/ActivityControllerTest.cs
+++ b/GirafRest.Test/Controllers/ActivityControllerTest.cs
@@ -252,5 +252,52 @@ namespace GirafRest.Test
             Assert.Equal(ErrorCode.ActivityNotFound, res.ErrorCode);
         }
         #endregion
+
+        #region UpdateActivity
+        [Fact]
+        public void UpdateActivity_InvalidActivityDTO_MissingProperties()
+        {
+            ActivityController ac = InitializeTest();
+            GirafUser mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
+            _testContext.MockUserManager.MockLoginAsUser(mockUser);
+
+            ActivityDTO newActivity = null;
+
+            var res = ac.UpdateActivity(newActivity).Result;
+
+            Assert.False(res.Success);
+            Assert.Equal(ErrorCode.MissingProperties, res.ErrorCode);
+        }
+
+        [Fact]
+        public void UpdateActivity_InvalidActivityValidDTO_ActivityNotFound()
+        {
+            ActivityController ac = InitializeTest();
+            GirafUser mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
+            _testContext.MockUserManager.MockLoginAsUser(mockUser);
+
+            ActivityDTO newActivity = new ActivityDTO() { Id = 420 };
+
+            var res = ac.UpdateActivity(newActivity).Result;
+
+            Assert.False(res.Success);
+            Assert.Equal(ErrorCode.ActivityNotFound, res.ErrorCode);
+        }
+
+        [Fact]
+        public void UpdateActivity_ValidActivityValidDTO_ActivitySucess()
+        {
+            ActivityController ac = InitializeTest();
+            GirafUser mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
+            _testContext.MockUserManager.MockLoginAsUser(mockUser);
+
+            ActivityDTO newActivity = new ActivityDTO() { Pictogram = new WeekPictogramDTO(_testContext.MockPictograms.First()) };
+
+            var res = ac.UpdateActivity(newActivity).Result;
+
+            Assert.True(res.Success);
+            Assert.Equal(newActivity.Pictogram.Id, res.Data.Pictogram.Id);
+        }
+        #endregion
     }
 }

--- a/GirafRest.Test/Controllers/ActivityControllerTest.cs
+++ b/GirafRest.Test/Controllers/ActivityControllerTest.cs
@@ -14,6 +14,9 @@ namespace GirafRest.Test
     {
         private const int ADMIN_DEP_ONE = 0;
         private const int GUARDIAN_DEP_TWO = 1;
+        private const int CITIZEN_NO_DEP = 9;
+
+        private const int PICTO_DEP_TWO = 6;
 
         private const int _existingId = 1;
         private const int _nonExistingId = 404;
@@ -263,7 +266,7 @@ namespace GirafRest.Test
 
             ActivityDTO newActivity = null;
 
-            var res = ac.UpdateActivity(newActivity).Result;
+            var res = ac.UpdateActivity(newActivity, mockUser.Id).Result;
 
             Assert.False(res.Success);
             Assert.Equal(ErrorCode.MissingProperties, res.ErrorCode);
@@ -278,22 +281,38 @@ namespace GirafRest.Test
 
             ActivityDTO newActivity = new ActivityDTO() { Id = 420 };
 
-            var res = ac.UpdateActivity(newActivity).Result;
+            var res = ac.UpdateActivity(newActivity, mockUser.Id).Result;
 
             Assert.False(res.Success);
             Assert.Equal(ErrorCode.ActivityNotFound, res.ErrorCode);
         }
 
         [Fact]
-        public void UpdateActivity_ValidActivityValidDTO_ActivitySucess()
+        public void UpdateActivity_ValidActivityInvalidUser_ActivityNotFound()
         {
             ActivityController ac = InitializeTest();
-            GirafUser mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
+            GirafUser mockUser = _testContext.MockUsers[GUARDIAN_DEP_TWO];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
+            GirafUser differentMockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
 
             ActivityDTO newActivity = new ActivityDTO() { Pictogram = new WeekPictogramDTO(_testContext.MockPictograms.First()) };
 
-            var res = ac.UpdateActivity(newActivity).Result;
+            var res = ac.UpdateActivity(newActivity, differentMockUser.Id).Result;
+
+            Assert.False(res.Success);
+            Assert.Equal(ErrorCode.NotAuthorized, res.ErrorCode);
+        }
+
+        [Fact]
+        public void UpdateActivity_ValidActivityValidDTO_ActivitySucess()
+        {
+            ActivityController ac = InitializeTest();
+            GirafUser mockUser = _testContext.MockUsers[ADMIN_DEP_ONE]; 
+            _testContext.MockUserManager.MockLoginAsUser(mockUser);
+
+            ActivityDTO newActivity = new ActivityDTO() { Id = _testContext.MockActivities.First().Key, Pictogram = new WeekPictogramDTO(_testContext.MockPictograms.First()) };
+
+            var res = ac.UpdateActivity(newActivity, mockUser.Id).Result;
 
             Assert.True(res.Success);
             Assert.Equal(newActivity.Pictogram.Id, res.Data.Pictogram.Id);

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -120,7 +120,6 @@ namespace GirafRest.Controllers
             if (updateActivity == null)
                 return new ErrorResponse<ActivityDTO>(ErrorCode.ActivityNotFound);
 
-            updateActivity.Key = activity.Id;
             updateActivity.Order = activity.Order;
             updateActivity.State = activity.State;
             updateActivity.PictogramKey = activity.Pictogram.Id;

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -109,7 +109,7 @@ namespace GirafRest.Controllers
         /// <param name="activity">a serialized version of the activity that will be updated.</param>
         /// <returns>Returns <see cref="ActivityDTO"/> for the updated activity on success else MissingProperties or NotFound, 
         [HttpPatch("update")]
-        [Authorize]
+        [Authorize] 
         public async Task<Response<ActivityDTO>> UpdateActivity([FromBody] ActivityDTO activity)
         {
             if (activity == null)

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -102,5 +102,31 @@ namespace GirafRest.Controllers
 
             return new Response();
         }
+
+        /// <summary>
+        /// Updates an activity with a given id.
+        /// </summary>
+        /// <param name="activity">a serialized version of the activity that will be updated.</param>
+        /// <returns>Returns <see cref="ActivityDTO"/> for the updated activity on success else MissingProperties or NotFound, 
+        [HttpPatch("update")]
+        [Authorize]
+        public async Task<Response<ActivityDTO>> UpdateActivity([FromBody] ActivityDTO activity)
+        {
+            if (activity == null)
+                return new ErrorResponse<ActivityDTO>(ErrorCode.MissingProperties);
+
+            Activity updateActivity = _giraf._context.Activities.FirstOrDefault(a => a.Key == activity.Id);
+
+            if (updateActivity == null)
+                return new ErrorResponse<ActivityDTO>(ErrorCode.ActivityNotFound);
+
+            updateActivity.Key = activity.Id;
+            updateActivity.Order = activity.Order;
+            updateActivity.State = activity.State;
+
+            await _giraf._context.SaveChangesAsync();
+
+            return new Response<ActivityDTO>(new ActivityDTO(updateActivity, activity.Pictogram));
+        }
     }
 }

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -108,12 +108,26 @@ namespace GirafRest.Controllers
         /// </summary>
         /// <param name="activity">a serialized version of the activity that will be updated.</param>
         /// <returns>Returns <see cref="ActivityDTO"/> for the updated activity on success else MissingProperties or NotFound, 
-        [HttpPatch("update")]
+        [HttpPatch("{userId}/update")]
         [Authorize] 
-        public async Task<Response<ActivityDTO>> UpdateActivity([FromBody] ActivityDTO activity)
+        public async Task<Response<ActivityDTO>> UpdateActivity([FromBody] ActivityDTO activity, string userId)
         {
             if (activity == null)
+            {
                 return new ErrorResponse<ActivityDTO>(ErrorCode.MissingProperties);
+            }
+
+            GirafUser user = await _giraf.LoadUserWithWeekSchedules(userId);
+            if (user == null)
+                return new ErrorResponse<ActivityDTO>(ErrorCode.UserNotFound);
+
+            // check access rights
+            if (!await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user))
+                return new ErrorResponse<ActivityDTO>(ErrorCode.NotAuthorized);
+
+            // throws error if none of user's weeks' has the specific activity
+            if (!user.WeekSchedule.Any(w => w.Weekdays.Any(wd => wd.Activities.Any(act => act.Key == activity.Id))))
+                return new ErrorResponse<ActivityDTO>(ErrorCode.ActivityNotFound);
 
             Activity updateActivity = _giraf._context.Activities.FirstOrDefault(a => a.Key == activity.Id);
 

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -123,6 +123,7 @@ namespace GirafRest.Controllers
             updateActivity.Key = activity.Id;
             updateActivity.Order = activity.Order;
             updateActivity.State = activity.State;
+            updateActivity.PictogramKey = activity.Pictogram.Id;
 
             await _giraf._context.SaveChangesAsync();
 

--- a/GirafRest/Models/DTOs/ActivityDTO.cs
+++ b/GirafRest/Models/DTOs/ActivityDTO.cs
@@ -18,6 +18,14 @@
             this.State = weekdayResource.State;
         }
 
+        public ActivityDTO(Activity weekdayResource, WeekPictogramDTO pictogram)
+        {
+            this.Id = weekdayResource.Key;
+            this.Order = weekdayResource.Order;
+            this.State = weekdayResource.State;
+            this.Pictogram = pictogram;
+        }
+
         public ActivityDTO(){}
 
         public WeekPictogramDTO Pictogram { get; set; }

--- a/GirafRest/Models/DTOs/WeekPictogramDTO.cs
+++ b/GirafRest/Models/DTOs/WeekPictogramDTO.cs
@@ -13,17 +13,17 @@ namespace GirafRest.Models.DTOs
         /// <summary>
         /// The last time the pictogram was edited.
         /// </summary>
-        public DateTime LastEdit { get; internal set; }
+        public DateTime LastEdit { get; set; }
 
         /// <summary>
         /// The title of the pictogram.
         /// </summary>
-        public string Title { get; internal set; }
+        public string Title { get; set; }
 
         /// <summary>
         /// The accesslevel of the pictogram.
         /// </summary>
-        public AccessLevel? AccessLevel { get; internal set; }
+        public AccessLevel? AccessLevel { get; set; }
 
         public string ImageHash { get; set; }
         public string ImageUrl { get { return $"/v1/pictogram/{Id}/image/raw"; } }


### PR DESCRIPTION
Co-Authored-By: HaZz <hazzm22@users.noreply.github.com>
Closes #18

We do not think it is needed to authorize, as citizens also should be able to make updates to activities. 