### PR TITLE
Fixes 78

### DIFF
--- a/GirafIntegrationTest/test.py
+++ b/GirafIntegrationTest/test.py
@@ -1,13 +1,31 @@
 import unittest
+import sys
 from requests import get
 from requests.exceptions import ConnectionError
+from argparse import ArgumentParser
 from testlib import GIRAFTestResults, GIRAFTestRunner, compare, BASE_URL
+
+parser = ArgumentParser()
+parser.add_argument('--missing', action='store_true', help='print untested endpoints')
+parser.add_argument('--tested', action='store_true', help='print tested endpoints')
+
+args = parser.parse_args()
+
+# importing util globally borks the tests due to test class imports
+if args.missing:
+    from util import missing_endpoints
+    missing_endpoints()
+    sys.exit(0)
+if args.tested:
+    from util import tested_endpoints
+    tested_endpoints()
+    sys.exit(0)
 
 try:
     result = get(f'{BASE_URL}v1/Error').json()
 except ConnectionError:
     print('\033[91m' + 'Error:' + '\033[0m' + ' could not get response from server.\nExiting...')
-    exit(1)
+    sys.exit(1)
 
 # setup runner with high verbosity, variable printing on fail/error, and custom results class
 runner = GIRAFTestRunner(verbosity=5, tb_locals=True, resultclass=GIRAFTestResults)

--- a/GirafIntegrationTest/tests/__init__.py
+++ b/GirafIntegrationTest/tests/__init__.py
@@ -1,10 +1,10 @@
-from . import test_account_controller
-from . import test_authorization
-from . import test_department_controller
-from . import test_pictogram_controller
-from . import test_user_controller
-from . import test_week_controller
-from . import test_week_template_controller
+from .test_account_controller import TestAccountController
+from .test_authorization import TestAuthorization
+from .test_department_controller import TestDepartmentController
+from .test_pictogram_controller import TestPictogramController
+from .test_user_controller import TestUserController
+from .test_week_controller import TestWeekController
+from .test_week_template_controller import TestWeekTemplateController
 
 """
 Anything in this file is executed once this module, i.e. 'tests', is imported.

--- a/GirafIntegrationTest/tests/__init__.py
+++ b/GirafIntegrationTest/tests/__init__.py
@@ -5,6 +5,7 @@ from .test_pictogram_controller import TestPictogramController
 from .test_user_controller import TestUserController
 from .test_week_controller import TestWeekController
 from .test_week_template_controller import TestWeekTemplateController
+from .test_activity_controller import TestActivityController
 
 """
 Anything in this file is executed once this module, i.e. 'tests', is imported.

--- a/GirafIntegrationTest/tests/__init__.py
+++ b/GirafIntegrationTest/tests/__init__.py
@@ -6,6 +6,8 @@ from .test_user_controller import TestUserController
 from .test_week_controller import TestWeekController
 from .test_week_template_controller import TestWeekTemplateController
 from .test_activity_controller import TestActivityController
+from .test_error_controller import TestErrorController
+from .test_status_controller import TestStatusController
 
 """
 Anything in this file is executed once this module, i.e. 'tests', is imported.

--- a/GirafIntegrationTest/tests/test_account_controller.py
+++ b/GirafIntegrationTest/tests/test_account_controller.py
@@ -341,3 +341,29 @@ class TestAccountController(GIRAFTestCase):
                         headers=auth(guardian_token)).json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'InvalidProperties')
+
+    @order
+    def test_account_can_set_citizen1_password_invalid_token_should_fail(self):
+        """
+        Testing setting Citizen1's password with an invalid token
+
+        Endpoint: PUT:/v1/User/{id}/Account/password
+        """
+        data = {'password': 'brand-new-password', 'token': 'invalid-token'}
+        response = put(f'{BASE_URL}v1/User/{citizen1_id}/Account/password', json=data,
+                       headers=auth(guardian_token)).json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'MissingProperties')
+
+    @order
+    def test_account_can_set_citizen1_password_valid_token(self):
+        """
+        Testing setting Citizen1's password with an invalid token
+
+        Endpoint: PUT:/v1/User/{id}/Account/password
+        """
+        data = {'oldPassword': 'brand-new-password', 'newPassword': citizen1_reset_token}
+        response = put(f'{BASE_URL}v1/User/{citizen1_id}/Account/password', json=data,
+                       headers=auth(department_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')

--- a/GirafIntegrationTest/tests/test_activity_controller.py
+++ b/GirafIntegrationTest/tests/test_activity_controller.py
@@ -1,0 +1,113 @@
+from requests import get, post, put, delete, patch
+import time
+from testlib import order, BASE_URL, auth, GIRAFTestCase
+
+guardian_token = ""
+user_id = ""
+user_token = ""
+activity_id = ""
+class TestActivityController(GIRAFTestCase):
+    """
+    Testing API requests on Activity endpoints
+    """
+    @classmethod
+    def setUpClass(cls) -> None:
+        """
+        Setup necessary data when class is loaded
+        """
+        super(TestActivityController, cls).setUpClass()
+        print(f'file:/{__file__}\n')
+        cls.weekplan_name = 'Normal Uge'
+        cls.week_year = 0
+        cls.week_number = 0
+        cls.week_day_number = 1
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Remove or resolve necessary data and states after class tests are done
+        """
+        super(TestActivityController, cls).tearDownClass()
+
+    @order
+    def test_activity_can_login_as_guardian(self):
+        """
+        Testing logging in as Guardian
+
+        Endpoint: POST:/v1/Account/login
+        """
+        global guardian_token
+        data = {'username': 'graatand', 'password': 'password'}
+        response = post(f'{BASE_URL}v1/Account/login', json=data).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        self.assertIsNotNone(response['data'])
+        guardian_token = response['data']
+
+    @order
+    def test_activity_can_login_as_citizen1(self):
+        """
+        Testing logging in as Citizen1
+
+        Endpoint: POST:/v1/Account/login
+        """
+        global user_token
+        data = {'username': 'Kurt', 'password': 'password'}
+        response = post(f'{BASE_URL}v1/Account/login', json=data).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        self.assertIsNotNone(response['data'])
+        user_token = response['data']
+
+    @order
+    def test_activity_can_get_citizen1_id(self):
+        """
+        Testing getting Citizen1's id
+
+        Endpoint: GET:/v1/User
+        """
+        global user_id
+        response = get(f'{BASE_URL}v1/User', headers=auth(user_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        self.assertIsNotNone(response['data'])
+        user_id = response['data']['id']
+
+    @order
+    def test_activity_set_new_user_activity(self):
+        """
+        Testing creation of user specific activity
+
+        Endpoint: POST:/v2/Activity/{user_id}/{weekplan_name}/{week_year}/{week_number}/{week_day_number}
+        """
+        global activity_id
+        data = {"pictogram": {"id": 1}}
+        response = post(f'{BASE_URL}v2/Activity/{user_id}/{self.weekplan_name}/{self.week_year}/{self.week_number}/{self.week_day_number}', headers=auth(guardian_token), json=data,).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        activity_id = response['data']['id']
+
+    @order
+    def test_activity_update_user_activity(self):
+        """
+        Testing PATCH update to activity for a specific user
+
+        Endpoint: PATCH:/v2/Activity/{user_id}/update
+        """
+        data = {'pictogram': {'title': 'sandbox'}}
+        response = patch(f'{BASE_URL}v2/Activity/{user_id}/update', data=data,
+                         headers=auth(guardian_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+
+
+    @order
+    def test_activity_delete_user_activity(self):
+        """
+        Testing DELETE on user specific activity
+
+        Endpoint: DELETE:/v2/Activity/{user_id}/delete/{activity_id}
+        """
+        response = delete(f'{BASE_URL}v2/Activity/{user_id}/delete/{activity_id}', headers=auth(guardian_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')

--- a/GirafIntegrationTest/tests/test_activity_controller.py
+++ b/GirafIntegrationTest/tests/test_activity_controller.py
@@ -94,8 +94,8 @@ class TestActivityController(GIRAFTestCase):
 
         Endpoint: PATCH:/v2/Activity/{user_id}/update
         """
-        data = {'pictogram': {'title': 'sandbox'}}
-        response = patch(f'{BASE_URL}v2/Activity/{user_id}/update', data=data,
+        data = {'pictogram': {'id': 6}, 'id': activity_id}
+        response = patch(f'{BASE_URL}v2/Activity/{user_id}/update', json=data,
                          headers=auth(guardian_token)).json()
         self.assertTrue(response['success'])
         self.assertEqual(response['errorKey'], 'NoError')

--- a/GirafIntegrationTest/tests/test_activity_controller.py
+++ b/GirafIntegrationTest/tests/test_activity_controller.py
@@ -100,7 +100,6 @@ class TestActivityController(GIRAFTestCase):
         self.assertTrue(response['success'])
         self.assertEqual(response['errorKey'], 'NoError')
 
-
     @order
     def test_activity_delete_user_activity(self):
         """

--- a/GirafIntegrationTest/tests/test_authorization.py
+++ b/GirafIntegrationTest/tests/test_authorization.py
@@ -1,4 +1,4 @@
-from requests import get, post, put, delete
+from requests import get, post, put, delete, patch
 from testlib import order, BASE_URL, GIRAFTestCase
 
 
@@ -19,6 +19,16 @@ class TestAuthorization(GIRAFTestCase):
                             "y9uYW1laWRlbnRpZmllciI6Ijg0MTJkOTk1LWIzODEtNGY4My1iZDI1LWU5ODY2NzBiNTdkOSIsImV4cCI6MT" \
                             "UyNTMwMzQyNSwiaXNzIjoibm90bWUiLCJhdWQiOiJub3RtZSJ9.8KXRRqF3B5s8tUki7u5j0TqK-189QIpApd" \
                             "OC6aSxOms"
+        cls.user_Id = 'john Doe'
+        cls.weekplan_Name = 'uge 2'
+        cls.week_Year = 2020
+        cls.week_Number = 17
+        cls.week_Day_Number = 4
+        cls.activity_Id = 2  # Might need to be existing activity id. chose 2
+        cls.department_Id = 1  # Might need another number
+        cls.citizen_Id = 'Jane Doe'
+
+
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -63,6 +73,76 @@ class TestAuthorization(GIRAFTestCase):
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
+    @order
+    def test_auth_POST_account_login_should_fail(self):
+        """
+        Testing account login
+
+        Endpoint: POST:/v1/Account/login
+        """
+        response = post(f'{BASE_URL}/v1/Account/login').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_POST_register_account_should_fail(self):
+        """
+        Testing account registration without authentication token
+
+        Endpoint: POST:/v1/Account/register
+        """
+        response = post(f'{BASE_URL}/v1/Account/register').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_DELETE_account_should_fail(self):
+        """
+        Testing account DELETION with authentication token
+
+        Endpoint: DELETE:/v1/Account/user/{user_id}
+        """
+        response = delete(f'{BASE_URL}/v1/Account/user/1').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+
+    """
+    Activity endpoints
+    """
+    @order
+    def test_auth_POST_weekplanner_activity_should_fail(self):
+        """
+        Testing creation of weekplanner activity without authentication token
+
+        Endpoint: POST:/v2/Activity/{user_id}/{weekplan_name}/{week_year}/{week_number}/{week_day_number}
+        """
+        response = post(f'{BASE_URL}/v2/Activity/{self.user_Id}/{self.weekplan_Name}/{self.week_Year}/{self.week_Number}/{self.week_Day_Number}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_DELETE_activity_should_fail(self):
+        """
+        Testing DELETION of activity without authentication token
+
+        Endpoint: DELETE:/v2/Activity/{user_id}/delete/{activity_id}
+        """
+        response = delete(f'{BASE_URL}/v2/Activity/{self.user_Id}/delete/{self.activity_Id}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_PATCH_update_activity_should_fail(self):
+        """
+        Testing PATCHING of activity or updating it without authentication token
+
+        Endpoint: PATCH:/v2/Activity/{user_id}/update
+        """
+        response = patch(f'{BASE_URL}/v2/Activity/{self.user_Id}/update').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
     """
     Department endpoints
     """
@@ -99,6 +179,50 @@ class TestAuthorization(GIRAFTestCase):
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
+    @order
+    def test_auth_GET_department_should_fail(self):
+        """
+        Testing GET on department
+
+        Endpoint: GET:/v1/Department
+        """
+        response = get(f'{BASE_URL}/v1/Department').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_GET_department_id_should_fail(self):
+        """
+        Testing GET on department id
+
+        Endpoint: GET:/v1/Department/{id}
+        """
+        response = get(f'{BASE_URL}/v1/Department/{self.department_Id}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_PUT_department_id_name_should_fail(self):
+        """
+        Testing PUT on department id name
+
+        Endpoint: PUT:/v1/Department/{id}/name
+        """
+        response = put(f'{BASE_URL}/v1/Department/{self.department_Id}/name').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_DELETE_department_id_should_fail(self):
+        """
+        Testing DELETE on department id
+
+        Endpoint: DELETE:/v1/Department/{id}
+        """
+        response = delete(f'{BASE_URL}/v1/Department/{self.department_Id}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
     """
     Error endpoints
     """
@@ -121,6 +245,28 @@ class TestAuthorization(GIRAFTestCase):
         Endpoint: POST:/v1/Error
         """
         response = post(f'{BASE_URL}v1/Error').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_PUT_error_should_fail(self):
+        """
+        Testing PUT error
+
+        Endpoint: PUT:/v1/Error
+        """
+        response = put(f'{BASE_URL}/v1/Error').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_DELETE_error_should_fail(self):
+        """
+        Testing DELETE error
+
+        Endpoint: DELETE:/v1/Error
+        """
+        response = delete(f'{BASE_URL}/v1/Error').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -219,7 +365,7 @@ class TestAuthorization(GIRAFTestCase):
     Status endpoints
     """
     @order
-    def test_auth_GET_status_should_fail(self):
+    def test_auth_GET_status(self):
         """
         Testing getting API status
 
@@ -230,7 +376,7 @@ class TestAuthorization(GIRAFTestCase):
         self.assertEqual(response['errorKey'], 'NoError')
 
     @order
-    def test_auth_GET_database_status_should_fail(self):
+    def test_auth_GET_database_status(self):
         """
         Testing getting API database status
 
@@ -239,6 +385,17 @@ class TestAuthorization(GIRAFTestCase):
         response = get(f'{BASE_URL}v1/Status/database').json()
         self.assertTrue(response['success'])
         self.assertEqual(response['errorKey'], 'NoError')
+
+    @order
+    def test_auth_GET_status_version(self):
+        """
+        Testing GET status version
+
+        Endpoint: GET:/v1/Status/version-info
+        """
+        response = get(f'{BASE_URL}/v1/Status/version-info').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
 
     """
     User endpoints
@@ -350,6 +507,144 @@ class TestAuthorization(GIRAFTestCase):
         Endpoint: GET:/v1/User/{id}/guardians
         """
         response = get(f'{BASE_URL}v1/User/0/guardians').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_GET_user_id_should_fail(self):
+        """
+        Testing GET user Id
+
+        Endpoint: GET:/v1/User/{id}
+        """
+        response = get(f'{BASE_URL}/v1/User/{self.user_Id}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_POST_user_id_citizens_citizenid_should_fail(self):
+        """
+        Testing POST as guardian for citizen
+
+        Endpoint: POST:/v1/User/{id}/citizens/{citizen_id}
+        """
+        response = post(f'{BASE_URL}/v1/User/{self.user_Id}/citizens/{self.citizen_Id}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    """
+    Week endpoints
+    """
+    @order
+    def test_auth_GET_user_id_week_v2_should_fail(self):
+        """
+        Testing GET on user specific week v2
+
+        Endpoint: GET:/v2/User/{id}/week
+        """
+        response = get(f'{BASE_URL}/v2/User/{self.user_Id}/week').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_GET_user_id_week_v1_should_fail(self):
+        """
+        Testing GET on user specific week v1
+
+        Endpoint: GET:/v2/User/{id}/week
+        """
+        response = get(f'{BASE_URL}/v1/User/{self.user_Id}/week').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_GET_user_id_weekyear_weeknumber_should_fail(self):
+        """
+        Testing GET on user specific weekyear and number
+
+        Endpoint: GET:/v1/User/{id}/week/{week_year}/{week_number}
+        """
+        response = get(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_PUT_user_id_weekyear_weeknumber_should_fail(self):
+        """
+        Testing PUT on user specific weekyear and number
+
+        Endpoint: PUT:/v1/User/{id}/week/{week_year}/{week_number}
+        """
+        response = put(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_DELETE_user_id_weekyear_weeknumber_should_fail(self):
+        """
+        Testing DELETE on user specific weekyear and number
+
+        Endpoint: DELETE:/v1/User/{id}/week/{week_year}/{week_number}
+        """
+        response = delete(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    """
+    WeekTemplate endpoints
+    """
+    @order
+    def test_auth_GET_weektemplate_should_fail(self):
+        """
+        Testing GET on weektemplate
+
+        Endpoint: GET:/v1/WeekTemplate
+        """
+        response = get(f'{BASE_URL}/v1/WeekTemplate').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_POST_weektemplate_should_fail(self):
+        """
+        Testing POST on weektemplate
+
+        Endpoint: POST:/v1/WeekTemplate
+        """
+        response = post(f'{BASE_URL}/v1/WeekTemplate').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_GET_weektemplate_id_should_fail(self):
+        """
+        Testing GET on weektemplate id
+
+        Endpoint: GET:/v1/WeekTemplate/{id}
+        """
+        response = get(f'{BASE_URL}/v1/WeekTemplate').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_PUT_weektemplate_id_should_fail(self):
+        """
+        Testing PUT on weektemplate id
+
+        Endpoint: PUT:/v1/WeekTemplate/{id}
+        """
+        response = put(f'{BASE_URL}/v1/WeekTemplate').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_auth_DELETE_weektemplate_id_should_fail(self):
+        """
+        Testing DELETE on weektemplate id
+
+        Endpoint: DELETE:/v1/WeekTemplate/{id}
+        """
+        response = delete(f'{BASE_URL}/v1/WeekTemplate').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 

--- a/GirafIntegrationTest/tests/test_authorization.py
+++ b/GirafIntegrationTest/tests/test_authorization.py
@@ -19,12 +19,12 @@ class TestAuthorization(GIRAFTestCase):
                             "y9uYW1laWRlbnRpZmllciI6Ijg0MTJkOTk1LWIzODEtNGY4My1iZDI1LWU5ODY2NzBiNTdkOSIsImV4cCI6MT" \
                             "UyNTMwMzQyNSwiaXNzIjoibm90bWUiLCJhdWQiOiJub3RtZSJ9.8KXRRqF3B5s8tUki7u5j0TqK-189QIpApd" \
                             "OC6aSxOms"
-        cls.user_Id = 'john Doe'
-        cls.weekplan_Name = 'uge 2'
-        cls.week_Year = 2020
-        cls.week_Number = 17
-        cls.week_Day_Number = 4
-        cls.activity_Id = 2  # Might need to be existing activity id. chose 2
+        cls.user_Id = "683c5e7d-b244-4ac8-bb12-b7295595a0f0"
+        cls.weekplan_Name = 'Normal Uge'
+        cls.week_Year = 0
+        cls.week_Number = 0
+        cls.week_Day_Number = 1
+        cls.activity_Id = 1  # Might need to be existing activity id. chose 2
         cls.department_Id = 1  # Might need another number
         cls.citizen_Id = 'Jane Doe'
 
@@ -45,20 +45,20 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing setting password
 
-        Endpoint: POST::/v1/User/{id}/Account/password
+        Endpoint: POST:/v1/User/{id}/Account/password
         """
-        response = post(f'{BASE_URL}v1/User/0/Account/password').json()
+        response = post(f'{BASE_URL}v1/User/{self.user_Id}/Account/password').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
     @order
-    def test_auth_POST_account_change_password_should_fail(self):
+    def test_auth_PUT_account_change_password_should_fail(self):
         """
         Testing changing password
 
         Endpoint: PUT:/v1/User/{id}/Account/password
         """
-        response = put(f'{BASE_URL}v1/User/0/Account/password').json()
+        response = put(f'{BASE_URL}v1/User/{self.user_Id}/Account/password').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -69,7 +69,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/User/{id}/Account/password-reset-token
         """
-        response = get(f'{BASE_URL}v1/User/0/Account/password-reset-token').json()
+        response = get(f'{BASE_URL}v1/User/{self.user_Id}/Account/password-reset-token').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -102,7 +102,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: DELETE:/v1/Account/user/{id}
         """
-        response = delete(f'{BASE_URL}/v1/Account/user/1').json()
+        response = delete(f'{BASE_URL}/v1/Account/user/{self.user_Id}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -163,7 +163,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/Department/{id}/citizens
         """
-        response = get(f'{BASE_URL}v1/Department/0/citizens').json()
+        response = get(f'{BASE_URL}v1/Department/{self.department_Id}/citizens').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -174,7 +174,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: POST:/v1/Department/{departmentId}/user/{userId}
         """
-        response = post(f'{BASE_URL}v1/Department/0/user/0').json()
+        response = post(f'{BASE_URL}v1/Department/{self.department_Id}/user/{self.user_Id}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -572,7 +572,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing PUT on user specific weekyear and number
 
-        Endpoint: PUT:/v1/User/{id}/week/{week_year}/{week_number}
+        Endpoint: PUT:/v1/User/{userId}/week/{weekYear}/{weekNumber}
         """
         response = put(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
         self.assertFalse(response['success'])
@@ -583,7 +583,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing DELETE on user specific weekyear and number
 
-        Endpoint: DELETE:/v1/User/{id}/week/{week_year}/{week_number}
+        Endpoint: DELETE:/v1/User/{userId}/week/{weekYear}/{weekNumber}
         """
         response = delete(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
         self.assertFalse(response['success'])

--- a/GirafIntegrationTest/tests/test_authorization.py
+++ b/GirafIntegrationTest/tests/test_authorization.py
@@ -80,7 +80,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: POST:/v1/Account/login
         """
-        response = post(f'{BASE_URL}/v1/Account/login').json()
+        response = post(f'{BASE_URL}v1/Account/login').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -91,7 +91,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: POST:/v1/Account/register
         """
-        response = post(f'{BASE_URL}/v1/Account/register').json()
+        response = post(f'{BASE_URL}v1/Account/register').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -102,7 +102,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: DELETE:/v1/Account/user/{id}
         """
-        response = delete(f'{BASE_URL}/v1/Account/user/{self.user_Id}').json()
+        response = delete(f'{BASE_URL}v1/Account/user/{self.user_Id}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -116,7 +116,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: POST:/v2/Activity/{user_id}/{weekplan_name}/{week_year}/{week_number}/{week_day_number}
         """
-        response = post(f'{BASE_URL}/v2/Activity/{self.user_Id}/{self.weekplan_Name}/{self.week_Year}/{self.week_Number}/{self.week_Day_Number}').json()
+        response = post(f'{BASE_URL}v2/Activity/{self.user_Id}/{self.weekplan_Name}/{self.week_Year}/{self.week_Number}/{self.week_Day_Number}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -127,7 +127,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: DELETE:/v2/Activity/{user_id}/delete/{activity_id}
         """
-        response = delete(f'{BASE_URL}/v2/Activity/{self.user_Id}/delete/{self.activity_Id}').json()
+        response = delete(f'{BASE_URL}v2/Activity/{self.user_Id}/delete/{self.activity_Id}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -138,7 +138,8 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: PATCH:/v2/Activity/{user_id}/update
         """
-        response = patch(f'{BASE_URL}/v2/Activity/{self.user_Id}/update').json()
+        data = {'pictogram': {'id': 6}, 'id': 1}
+        response = patch(f'{BASE_URL}v2/Activity/{self.user_Id}/update', json=data).json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -185,9 +186,9 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/Department
         """
-        response = get(f'{BASE_URL}/v1/Department').json()
-        self.assertFalse(response['success'])
-        self.assertEqual(response['errorKey'], 'NotFound')
+        response = get(f'{BASE_URL}v1/Department').json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
 
     @order
     def test_auth_GET_department_id_should_fail(self):
@@ -196,9 +197,9 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/Department/{id}
         """
-        response = get(f'{BASE_URL}/v1/Department/{self.department_Id}').json()
+        response = get(f'{BASE_URL}v1/Department/{self.department_Id}').json()
         self.assertFalse(response['success'])
-        self.assertEqual(response['errorKey'], 'NotFound')
+        self.assertEqual(response['errorKey'], 'UserNotFound')
 
     @order
     def test_auth_PUT_department_id_name_should_fail(self):
@@ -207,7 +208,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: PUT:/v1/Department/{id}/name
         """
-        response = put(f'{BASE_URL}/v1/Department/{self.department_Id}/name').json()
+        response = put(f'{BASE_URL}v1/Department/{self.department_Id}/name').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -218,7 +219,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: DELETE:/v1/Department/{id}
         """
-        response = delete(f'{BASE_URL}/v1/Department/{self.department_Id}').json()
+        response = delete(f'{BASE_URL}v1/Department/{self.department_Id}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -254,7 +255,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: PUT:/v1/Error
         """
-        response = put(f'{BASE_URL}/v1/Error').json()
+        response = put(f'{BASE_URL}v1/Error').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -265,7 +266,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: DELETE:/v1/Error
         """
-        response = delete(f'{BASE_URL}/v1/Error').json()
+        response = delete(f'{BASE_URL}v1/Error').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -392,9 +393,9 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/Status/version-info
         """
-        response = get(f'{BASE_URL}/v1/Status/version-info').json()
-        self.assertFalse(response['success'])
-        self.assertEqual(response['errorKey'], 'NotFound')
+        response = get(f'{BASE_URL}v1/Status/version-info').json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
 
     """
     User endpoints
@@ -516,7 +517,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/User/{id}
         """
-        response = get(f'{BASE_URL}/v1/User/{self.user_Id}').json()
+        response = get(f'{BASE_URL}v1/User/{self.user_Id}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -527,7 +528,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: POST:/v1/User/{userId}/citizens/{citizenId}
         """
-        response = post(f'{BASE_URL}/v1/User/{self.user_Id}/citizens/{self.citizen_Id}').json()
+        response = post(f'{BASE_URL}v1/User/{self.user_Id}/citizens/{self.citizen_Id}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -541,7 +542,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v2/User/{userId}/week
         """
-        response = get(f'{BASE_URL}/v2/User/{self.user_Id}/week').json()
+        response = get(f'{BASE_URL}v2/User/{self.user_Id}/week').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -552,7 +553,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/User/{userId}/week
         """
-        response = get(f'{BASE_URL}/v1/User/{self.user_Id}/week').json()
+        response = get(f'{BASE_URL}v1/User/{self.user_Id}/week').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -563,7 +564,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/User/{userId}/week/{weekYear}/{weekNumber}
         """
-        response = get(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
+        response = get(f'{BASE_URL}v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -574,7 +575,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: PUT:/v1/User/{userId}/week/{weekYear}/{weekNumber}
         """
-        response = put(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
+        response = put(f'{BASE_URL}v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -585,7 +586,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: DELETE:/v1/User/{userId}/week/{weekYear}/{weekNumber}
         """
-        response = delete(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
+        response = delete(f'{BASE_URL}v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -599,7 +600,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/WeekTemplate
         """
-        response = get(f'{BASE_URL}/v1/WeekTemplate').json()
+        response = get(f'{BASE_URL}v1/WeekTemplate').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -610,7 +611,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: POST:/v1/WeekTemplate
         """
-        response = post(f'{BASE_URL}/v1/WeekTemplate').json()
+        response = post(f'{BASE_URL}v1/WeekTemplate').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -621,7 +622,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: GET:/v1/WeekTemplate/{id}
         """
-        response = get(f'{BASE_URL}/v1/WeekTemplate').json()
+        response = get(f'{BASE_URL}v1/WeekTemplate').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -632,7 +633,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: PUT:/v1/WeekTemplate/{id}
         """
-        response = put(f'{BASE_URL}/v1/WeekTemplate').json()
+        response = put(f'{BASE_URL}v1/WeekTemplate').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 
@@ -643,7 +644,7 @@ class TestAuthorization(GIRAFTestCase):
 
         Endpoint: DELETE:/v1/WeekTemplate/{id}
         """
-        response = delete(f'{BASE_URL}/v1/WeekTemplate').json()
+        response = delete(f'{BASE_URL}v1/WeekTemplate').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
 

--- a/GirafIntegrationTest/tests/test_authorization.py
+++ b/GirafIntegrationTest/tests/test_authorization.py
@@ -45,7 +45,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing setting password
 
-        Endpoint: POST:/v1/Account/login
+        Endpoint: POST::/v1/User/{id}/Account/password
         """
         response = post(f'{BASE_URL}v1/User/0/Account/password').json()
         self.assertFalse(response['success'])
@@ -100,12 +100,11 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing account DELETION with authentication token
 
-        Endpoint: DELETE:/v1/Account/user/{user_id}
+        Endpoint: DELETE:/v1/Account/user/{id}
         """
         response = delete(f'{BASE_URL}/v1/Account/user/1').json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotFound')
-
 
     """
     Activity endpoints
@@ -493,7 +492,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing getting user citizens by user id
 
-        Endpoint: GET:/v1/User/{id}/citizens
+        Endpoint: GET:/v1/User/{userId}/citizens
         """
         response = get(f'{BASE_URL}v1/User/0/citizens').json()
         self.assertFalse(response['success'])
@@ -504,7 +503,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing getting user guardians by user id
 
-        Endpoint: GET:/v1/User/{id}/guardians
+        Endpoint: GET:/v1/User/{userId}/guardians
         """
         response = get(f'{BASE_URL}v1/User/0/guardians').json()
         self.assertFalse(response['success'])
@@ -526,7 +525,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing POST as guardian for citizen
 
-        Endpoint: POST:/v1/User/{id}/citizens/{citizen_id}
+        Endpoint: POST:/v1/User/{userId}/citizens/{citizenId}
         """
         response = post(f'{BASE_URL}/v1/User/{self.user_Id}/citizens/{self.citizen_Id}').json()
         self.assertFalse(response['success'])
@@ -540,7 +539,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing GET on user specific week v2
 
-        Endpoint: GET:/v2/User/{id}/week
+        Endpoint: GET:/v2/User/{userId}/week
         """
         response = get(f'{BASE_URL}/v2/User/{self.user_Id}/week').json()
         self.assertFalse(response['success'])
@@ -551,7 +550,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing GET on user specific week v1
 
-        Endpoint: GET:/v2/User/{id}/week
+        Endpoint: GET:/v1/User/{userId}/week
         """
         response = get(f'{BASE_URL}/v1/User/{self.user_Id}/week').json()
         self.assertFalse(response['success'])
@@ -562,7 +561,7 @@ class TestAuthorization(GIRAFTestCase):
         """
         Testing GET on user specific weekyear and number
 
-        Endpoint: GET:/v1/User/{id}/week/{week_year}/{week_number}
+        Endpoint: GET:/v1/User/{userId}/week/{weekYear}/{weekNumber}
         """
         response = get(f'{BASE_URL}/v1/User/{self.user_Id}/week/{self.week_Year}/{self.week_Number}').json()
         self.assertFalse(response['success'])

--- a/GirafIntegrationTest/tests/test_department_controller.py
+++ b/GirafIntegrationTest/tests/test_department_controller.py
@@ -194,7 +194,7 @@ class TestDepartmentController(GIRAFTestCase):
     @order
     def test_department_can_register_citizen2_department(self):
         """
-        Testing registering Citizen1 in newly created department
+        Testing registering Citizen2 in newly created department
 
         Endpoint: POST:/v1/Account/register
         """
@@ -374,5 +374,41 @@ class TestDepartmentController(GIRAFTestCase):
         """
         response = delete(f'{BASE_URL}v1/Department/resource/{pictograms["cyclopean"]["id"]}',
                           headers=auth(department_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+
+    @order
+    def test_department_can_get_citizen_names(self):
+        """
+        Testing if superuser can get names of people in a department by department id
+
+        Endpoint: GET:/v1/Department/{id}/citizens
+        """
+        response = get(f'{BASE_URL}v1/Department/{department_id}/citizens', headers=auth(super_user_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+
+    @order
+    def test_department_can_change_name_of_department_as_superuser(self):
+        """
+        Testing changing name of department as superuser
+
+        Endpoint: PUT:/v1/Department/{id}/name
+        """
+        x = auth(super_user_token)
+        x['Content-Type'] = 'application/json-patch+json'
+        data = {'id': department_id, 'name': 'DeleteMe'}
+        response = put(f'{BASE_URL}v1/Department/{department_id}/name', json=data, headers=x).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+
+    @order
+    def test_department_can_delete_department_as_superuser(self):
+        """
+        Testing removing created department by id as superuser
+
+        Endpoint: DELETE:/v1/Department/{id}
+        """
+        response = delete(f'{BASE_URL}v1/Department/{department_id}', headers=auth(super_user_token)).json()
         self.assertTrue(response['success'])
         self.assertEqual(response['errorKey'], 'NoError')

--- a/GirafIntegrationTest/tests/test_department_controller.py
+++ b/GirafIntegrationTest/tests/test_department_controller.py
@@ -15,9 +15,9 @@ department_count = 0
 pictograms = {}
 
 
-class TestAccountController(GIRAFTestCase):
+class TestDepartmentController(GIRAFTestCase):
     """
-    Testing API requests on Account endpoints
+    Testing API requests on Department endpoints
     """
 
     @classmethod
@@ -25,7 +25,7 @@ class TestAccountController(GIRAFTestCase):
         """
         Setup necessary data when class is loaded
         """
-        super(TestAccountController, cls).setUpClass()
+        super(TestDepartmentController, cls).setUpClass()
         print(f'file:/{__file__}\n')
         cls.DEPARTMENT = {'id': 0, 'name': department_username, 'members': [], 'resources': []}
         cls.NEW_PICTOGRAMS = [{'accessLevel': 3, 'title': 'Cyclopean', 'id': -1,
@@ -40,7 +40,7 @@ class TestAccountController(GIRAFTestCase):
         """
         Remove or resolve necessary data and states after class tests are done
         """
-        super(TestAccountController, cls).tearDownClass()
+        super(TestDepartmentController, cls).tearDownClass()
 
     @order
     def test_department_can_login_as_super_user(self):

--- a/GirafIntegrationTest/tests/test_error_controller.py
+++ b/GirafIntegrationTest/tests/test_error_controller.py
@@ -1,0 +1,81 @@
+from requests import get, post, put, delete
+import time
+from testlib import order, BASE_URL, auth, GIRAFTestCase
+
+class TestErrorController(GIRAFTestCase):
+    """
+    Testing API requests on Error endpoints.
+    """
+    @classmethod
+    def setUpClass(cls) -> None:
+        """
+        Setup necessary data when class is loaded
+        """
+        super(TestErrorController, cls).setUpClass()
+        print(f'file:/{__file__}\n')
+
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Remove or resolve necessary data and states after class tests are done
+        """
+        super(TestErrorController, cls).tearDownClass()
+
+    @order
+    def test_ERROR_can_get_error(self):
+        """
+        Testing GET error
+
+        Endpoint: GET:/v1/Error
+        """
+        response = get(f'{BASE_URL}v1/Error').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_ERROR_can_put_error(self):
+        """
+        Testing PUT error
+
+        Endpoint: PUT:/v1/Error
+        """
+        response = put(f'{BASE_URL}v1/Error').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_ERROR_can_post_error(self):
+        """
+        Testing POST error
+
+        Endpoint: POST:/v1/Error
+        """
+        response = post(f'{BASE_URL}v1/Error').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_ERROR_can_delete_error(self):
+        """
+        Testing DELETE error
+
+        Endpoint: DELETE:/v1/Error
+        """
+        response = delete(f'{BASE_URL}v1/Error').json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+
+    @order
+    def test_error_lul(self):
+        """
+        Doing dumb shit here. This test should get redirected to the Error endpoint.
+
+        Endpoint: DELETE:/v1/Error
+        """
+        response = delete(f'{BASE_URL}hahahaha/')
+        x = response.url
+        response = response.json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NotFound')
+

--- a/GirafIntegrationTest/tests/test_status_controller.py
+++ b/GirafIntegrationTest/tests/test_status_controller.py
@@ -1,0 +1,56 @@
+from requests import get, post, put, delete
+import time
+from testlib import order, BASE_URL, auth, GIRAFTestCase
+
+class TestStatusController(GIRAFTestCase):
+    """
+    Testing API requests on Error endpoints.
+    """
+    @classmethod
+    def setUpClass(cls) -> None:
+        """
+        Setup necessary data when class is loaded
+        """
+        super(TestStatusController, cls).setUpClass()
+        print(f'file:/{__file__}\n')
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        """
+        Remove or resolve necessary data and states after class tests are done
+        """
+        super(TestStatusController, cls).tearDownClass()
+
+    @order
+    def test_status_is_online(self):
+        """
+        Testing GET for status on web-api
+
+        Endpoint: GET:/v1/Status
+        """
+        response = get(f'{BASE_URL}v1/status').json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+
+    @order
+    def test_status_webapi_database_connection_is_online(self):
+        """
+        Testing GET for status on web-api connection to database
+
+        Endpoint: GET:/v1/Status/database
+        """
+        response = get(f'{BASE_URL}v1/status/database').json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+
+    @order
+    def test_status_versioninfo_is_online(self):
+        """
+        Testing GET for status on web-api
+
+        Endpoint: GET:/v1/Status/version-info
+        """
+        response = get(f'{BASE_URL}v1/status/version-info').json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        self.assertIsNotNone(response['data'])

--- a/GirafIntegrationTest/tests/test_user_controller.py
+++ b/GirafIntegrationTest/tests/test_user_controller.py
@@ -559,7 +559,7 @@ class TestUserController(GIRAFTestCase):
 
         Endpoint: PUT:/v1/User/{id}/icon
         """
-        data = self.RAW_IMAGE
+        data = {'userIcon': self.RAW_IMAGE}
         response = put(f'{BASE_URL}v1/User/{citizen2_id}/icon', json=data, headers=auth(super_user_token)).json()
         self.assertTrue(response['success'])
         self.assertEqual(response['errorKey'], 'NoError')
@@ -571,7 +571,7 @@ class TestUserController(GIRAFTestCase):
 
         Endpoint: PUT:/v1/User/{id}/icon
         """
-        data = self.RAW_IMAGE
+        data = {'userIcon': self.RAW_IMAGE}
         response = put(f'{BASE_URL}v1/User/{citizen2_id}/icon', data=data, headers=auth(citizen1_token)).json()
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'NotAuthorized')
@@ -583,20 +583,34 @@ class TestUserController(GIRAFTestCase):
 
         Endpoint: PUT:/v1/User/{id}/icon
         """
-        data = self.RAW_IMAGE
+        data = {'userIcon': self.RAW_IMAGE}
         response = put(f'{BASE_URL}v1/User/{citizen2_id}/icon', json=data, headers=auth(guardian_token)).json()
         self.assertTrue(response['success'])
         self.assertEqual(response['errorKey'], 'NoError')
+
+    @order
+    def test_user_user_can_get_own_icon(self):
+        """
+        Testing if a user can get own userIcon
+
+        Endpoint: GET:/v1/User/{id}/icon
+        """
+        response = get(f'{BASE_URL}v1/User/{citizen2_id}/icon', headers=auth(citizen2_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        self.assertIsNotNone(response['data'])
+
 
     @order
     def test_user_user_can_get_specific_user_icon(self):
         """
         Testing if a user can get the userIcon of another user
 
-        Endpoint: GET:/v1/User/id/icon
+        Endpoint: GET:/v1/User/{id}/icon
         """
         response = get(f'{BASE_URL}v1/User/{citizen2_id}/icon', headers=auth(citizen1_token)).json()
         self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
         self.assertIsNotNone(response['data'])
 
     @order
@@ -604,22 +618,59 @@ class TestUserController(GIRAFTestCase):
         """
         Testing if a guardian can get the userIcon of another user
 
-        Endpoint: GET:/v1/User/id/icon
+        Endpoint: GET:/v1/User/{id}/icon
         """
         response = get(f'{BASE_URL}v1/User/{citizen2_id}/icon', headers=auth(guardian_token)).json()
         self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
         self.assertIsNotNone(response['data'])
 
     @order
     def test_user_superuser_can_get_specific_user_icon(self):
         """
-        Testing if a user can get the userIcon of another user
+        Testing if a superuser can get the userIcon of another user
 
-        Endpoint: GET:/v1/User/id/icon
+        Endpoint: GET:/v1/User/{id}/icon
         """
         response = get(f'{BASE_URL}v1/User/{citizen2_id}/icon', headers=auth(super_user_token)).json()
         self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
         self.assertIsNotNone(response['data'])
+
+    @order
+    def test_user_superuser_can_get_specific_user_icon(self):
+        """
+        Testing if a superuser can get the raw userIcon of another user
+
+        Endpoint: GET:/v1/User/{id}/icon/raw
+        """
+        response = get(f'{BASE_URL}v1/User/{citizen2_id}/icon/raw', headers=auth(super_user_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        self.assertIsNotNone(response['data'])
+
+    @order
+    def test_user_superuser_can_delete_specific_user_icon(self):
+        """
+        Testing if a superuser can delete the userIcon of another user
+
+        Endpoint: DELETE:/v1/User/{id}/icon
+        """
+        response = delete(f'{BASE_URL}v1/User/{citizen2_id}/icon', headers=auth(super_user_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        self.assertIsNotNone(response['data'])
+
+    @order
+    def test_user_guardian_add_relation_to_user(self):
+        """
+        Testing if guardian can add relation to existing citizen
+
+        Endpoint: POST:/v1/User/{userId}/citizens/{citizenId}
+        """
+        response = post(f'{BASE_URL}v1/User/{new_guardian_id}/citizens/{citizen2_id}', headers=auth(new_guardian_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
 
     @order
     def test_user_delete_new_guardian(self):

--- a/GirafIntegrationTest/tests/test_user_controller.py
+++ b/GirafIntegrationTest/tests/test_user_controller.py
@@ -235,7 +235,7 @@ class TestUserController(GIRAFTestCase):
         """
         Testing getting Citizen3's id with Citizen2
 
-        Endpoint: GET:/v1/User/{userId}
+        Endpoint: GET:/v1/User/{id}
         """
         response = get(f'{BASE_URL}v1/User/{citizen3_id}', headers=auth(citizen2_token)).json()
         self.assertFalse(response['success'])
@@ -246,7 +246,7 @@ class TestUserController(GIRAFTestCase):
         """
         Testing getting citizen info as guardian
 
-        Endpoint: GET:/v1/User/{userId}
+        Endpoint: GET:/v1/User/{id}
         """
         response = get(f'{BASE_URL}v1/User/{citizen2_id}', headers=auth(guardian_token)).json()
         self.assertTrue(response['success'])
@@ -259,7 +259,7 @@ class TestUserController(GIRAFTestCase):
         """
         Testing setting display name
 
-        Endpoint: PUT:/v1/User/{userId}
+        Endpoint: PUT:/v1/User/{id}
         """
         data = {'username': citizen2_username, 'screenName': 'FBI Surveillance Van'}
         response = put(f'{BASE_URL}v1/User/{citizen2_id}', headers=auth(citizen2_token), json=data).json()
@@ -284,7 +284,7 @@ class TestUserController(GIRAFTestCase):
         """
         Testing adding new pictogram as Citizen2
 
-        Endpoint: Post:/v1/Pictogram
+        Endpoint: POST:/v1/Pictogram
         """
         global wednesday_id
         data = {'accessLevel': 3, 'title': 'wednesday', 'id': 5, 'lastEdit': '2018-03-19T10:40:26.587Z'}
@@ -409,7 +409,7 @@ class TestUserController(GIRAFTestCase):
         """
         Testing getting Citizen1's citizens
 
-        Endpoint: GET:/v1/User/{id}/citizens
+        Endpoint: GET:/v1/User/{userId}/citizens
         """
         response = get(f'{BASE_URL}v1/User/{citizen1_id}/citizens', headers=auth(citizen1_token)).json()
         self.assertFalse(response['success'])
@@ -420,7 +420,7 @@ class TestUserController(GIRAFTestCase):
         """
         Testing getting Guardian's citizens
 
-        Endpoint: GET:/v1/User/{id}/citizens
+        Endpoint: GET:/v1/User/{userId}/citizens
         """
         response = get(f'{BASE_URL}v1/User/{guardian_id}/citizens', headers=auth(guardian_token)).json()
         self.assertTrue(response['success'])
@@ -433,7 +433,7 @@ class TestUserController(GIRAFTestCase):
         """
         Testing getting Citizen1's guardians
 
-        Endpoint: GET:/v1/User/{id}/guardians
+        Endpoint: GET:/v1/User/{userId}/guardians
         """
         response = get(f'{BASE_URL}v1/User/{citizen1_id}/guardians', headers=auth(citizen1_token)).json()
         self.assertTrue(response['success'])
@@ -446,7 +446,7 @@ class TestUserController(GIRAFTestCase):
         """
         Testing getting Guardian's guardians
 
-        Endpoint: GET:/v1/User/{id}/guardians
+        Endpoint: GET:/v1/User/{userId}/guardians
         """
         response = get(f'{BASE_URL}v1/User/{guardian_id}/guardians', headers=auth(guardian_token)).json()
         self.assertFalse(response['success'])

--- a/GirafIntegrationTest/tests/test_week_controller.py
+++ b/GirafIntegrationTest/tests/test_week_controller.py
@@ -156,6 +156,20 @@ class TestWeekController(GIRAFTestCase):
         self.assertEqual(11, response['data'][0]['weekNumber'])
 
     @order
+    def test_week_can_get_new_weeks_new_v2_endpoint(self):
+        """
+        Testing getting list containing new week v2 endpoint
+
+        Endpoint: GET:/v2/User/{userId}/week
+        """
+        response = get(f'{BASE_URL}v2/User/{citizen_id}/week', headers=auth(citizen_token)).json()
+        self.assertTrue(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+        self.assertIsNotNone(response['data'])
+        self.assertEqual(2018, response['data'][0]['weekYear'])
+        self.assertEqual(11, response['data'][0]['weekNumber'])
+
+    @order
     def test_week_can_add_week_with_too_many_days_should_fail(self):
         """
         Testing adding week containing too many days

--- a/GirafIntegrationTest/util.py
+++ b/GirafIntegrationTest/util.py
@@ -1,0 +1,191 @@
+from tests import *
+
+TEST_CLASSES = [TestAccountController, TestAuthorization, TestDepartmentController,
+                TestPictogramController, TestUserController, TestWeekController,
+                TestWeekTemplateController]
+ENDPOINTS = {'Account': {'/v1/Account/login': ['POST'], '/v1/Account/register': ['POST'],
+                         '/v1/Account/user/{id}': ['DELETE'],
+                         '/v1/User/{id}/Account/password': ['PUT', 'POST'],
+                         '/v1/User/{id}/Account/password-reset-token': ['GET']},
+             'Activity': {'/v2/Activity/{user_id}/{weekplan_name}/{week_year}/{week_number}'
+                          '/{week_day_number}': ['POST'],
+                          '/v2/Activity/{user_id}/delete/{activity_id}': ['DELETE'],
+                          '/v2/Activity/{user_id}/update': ['PATCH']},
+             'Department': {'/v1/Department': ['GET', 'POST'],
+                            '/v1/Department/{id}': ['GET', 'DELETE'],
+                            '/v1/Department/{id}/citizens': ['GET'],
+                            '/v1/Department/{departmentId}/user/{userId}': ['POST'],
+                            '/v1/Department/{id}/name': ['PUT']},
+             'Error': {'/v1/Error': ['GET', 'PUT', 'POST', 'DELETE']},
+             'Pictogram': {'/v1/Pictogram': ['GET', 'POST'],
+                           '/v1/Pictogram/{id}': ['GET', 'PUT', 'DELETE'],
+                           '/v1/Pictogram/{id}/image': ['GET', 'PUT'],
+                           '/v1/Pictogram/{id}/image/raw': ['GET']},
+             'Status': {'/v1/Status': ['GET'], '/v1/Status/database': ['GET'],
+                        '/v1/Status/version-info': ['GET']},
+             'User': {'/v1/User': ['GET'], '/v1/User/{id}': ['GET', 'PUT'],
+                      '/v1/User/{id}/settings': ['GET', 'PUT'],
+                      '/v1/User/{id}/icon': ['GET', 'PUT', 'DELETE'],
+                      '/v1/User/{id}/icon/raw': ['GET'],
+                      '/v1/User/{userId}/citizens': ['GET'],
+                      '/v1/User/{userId}/guardians': ['GET'],
+                      '/v1/User/{userId}/citizens/{citizenId}': ['POST']},
+             'Week': {'/v2/User/{userId}/week': ['GET'], '/v1/User/{userId}/week': ['GET'],
+                      '/v1/User/{userId}/week/{weekYear}/{weekNumber}': ['GET', 'PUT', 'DELETE']},
+             'WeekTemplate': {'/v1/WeekTemplate': ['GET', 'POST'],
+                              '/v1/WeekTemplate/{id}': ['GET', 'PUT', 'DELETE']}}
+
+
+def missing_endpoints():
+    """
+    Prints missing endpoints based on globally defined dict 'ENDPOINTS'
+    """
+    missing = _missing()
+    print('#' * 50)
+    print(f'\t\tMissing tests')
+    for k, v in missing.items():
+        print()
+        print(f'{k} endpoints')
+        print('-' * 50)
+        for end, meths in v.items():
+            if meths:
+                print(f'Methods {meths} in endpoint {end} are NOT tested')
+
+
+def tested_endpoints():
+    """
+    Prints tested endpoints based on globally defined dict 'ENDPOINTS'
+    """
+    tested = _tested()
+    print(f'\t\tAlready tested')
+    for k, v in tested.items():
+        print()
+        print(f'{k} endpoints')
+        print('-' * 50)
+        for end, meths in v.items():
+            print(f'Methods {meths} in endpoint {end} are tested')
+
+
+def _missing() -> dict:
+    """
+    Collects missing endpoints
+    :return: missing endpoints as dict
+    """
+    missing = {'Authorization': {}}
+    tested = _tested()
+    for k, v in ENDPOINTS.items():
+        missing[k] = {}
+
+        # if no endpoints in this controller is tested, simply copy all endpoints
+        if k not in tested.keys():
+            missing[k] = v.copy()
+
+        for end, meths in v.items():
+            if end not in tested['Authorization'].keys():
+                # if endpoint is not tested, simply copy it with all methods
+                missing['Authorization'][end] = meths.copy()
+            else:
+                # if it is, append all tested methods
+                missing['Authorization'][end] = []
+                for meth in meths:
+                    try:
+                        if meth not in missing['Authorization'][end] and meth not in \
+                                tested['Authorization'][end]:
+                            missing['Authorization'][end].append(meth)
+                    except KeyError:
+                        missing['Authorization'][end].append(meth)
+
+            # if any endpoint in this controller are tested
+            if k in tested.keys():
+                if end not in tested[k].keys():
+                    # if this endpoint is not tested, simply copy it with all methods
+                    missing[k][end] = meths.copy()
+                else:
+                    # if it is, append all tested methods
+                    missing[k][end] = []
+                    for meth in meths:
+                        if meth not in missing[k][end] and meth not in tested[k][end]:
+                            missing[k][end].append(meth)
+
+    return missing
+
+
+def _tested() -> dict:
+    """
+    Collects tested endpoints
+    :return: tested endpoints as dict
+    """
+    tested = {'Authorization': {}}
+    cls_meth = _methods()
+
+    for k, v in ENDPOINTS.items():
+        tested[k] = {}
+
+        for end, meths in v.items():
+            # if any endpoint in this controller has been tested
+            if k in cls_meth.keys():
+                # if this endpoint has been tested
+                if end in cls_meth[k].keys():
+                    tested[k][end] = []
+                    for m in meths:
+                        # if this method has been tested, append
+                        if m in cls_meth[k][end]:
+                            tested[k][end].append(m)
+
+            # if any endpoint in this controller has been tested in test_authorization.py
+            if end in cls_meth['Authorization'].keys():
+                tested['Authorization'][end] = []
+                for m in meths:
+                    # if this method has been tested, append
+                    if m in cls_meth['Authorization'][end]:
+                        tested['Authorization'][end].append(m)
+    return tested
+
+
+def _methods() -> dict:
+    """
+    Extracts methods from test classes and puts them into a dict by their request method
+    and endpoint
+    :return: methods as dict
+    """
+    temp = {}
+    for cls in TEST_CLASSES:
+        # for each object in each test class, append as an object if
+        # it is callable, i.e. a method, and
+        # it is a test method, i.e. prefixed by 'test'
+        temp[_slice(cls.__name__)] = \
+            [getattr(cls(), meth) for meth in dir(cls()) if callable(getattr(cls(), meth))
+             and meth[:4] == 'test']
+    cls_meth = {}
+    # convert to dict of endpoints and request methods
+    for k, v in temp.items():
+        cls_meth[k] = {}
+        for func in v:
+            # get request method and endpoint and add to dict
+            meth, end = _endpoint(func.__doc__)
+            try:
+                cls_meth[k][end].append(meth)
+            except KeyError:
+                cls_meth[k][end] = [meth]
+    return cls_meth
+
+
+def _slice(name: str) -> str:
+    """
+    Extracts controller name
+    :param name: test class name
+    :return: controller name
+    """
+    endpoint_end = name.index('Controller') if 'Controller' in name else None
+    return name[4:endpoint_end]
+
+
+def _endpoint(doc: str) -> tuple:
+    """
+    Extracts request method and endpoint from method doc string
+    :param doc: doc string
+    :return: request method, endpoint
+    """
+    docs = [x.strip() for x in doc.strip().split('\n') if x]
+    endpoint = [x.strip() for x in docs[1].split(':')]
+    return endpoint[1], endpoint[2]

--- a/GirafIntegrationTest/util.py
+++ b/GirafIntegrationTest/util.py
@@ -2,7 +2,7 @@ from tests import *
 
 TEST_CLASSES = [TestAccountController, TestAuthorization, TestDepartmentController,
                 TestPictogramController, TestUserController, TestWeekController,
-                TestWeekTemplateController]
+                TestWeekTemplateController, TestActivityController]
 ENDPOINTS = {'Account': {'/v1/Account/login': ['POST'], '/v1/Account/register': ['POST'],
                          '/v1/Account/user/{id}': ['DELETE'],
                          '/v1/User/{id}/Account/password': ['PUT', 'POST'],

--- a/GirafIntegrationTest/util.py
+++ b/GirafIntegrationTest/util.py
@@ -2,7 +2,7 @@ from tests import *
 
 TEST_CLASSES = [TestAccountController, TestAuthorization, TestDepartmentController,
                 TestPictogramController, TestUserController, TestWeekController,
-                TestWeekTemplateController, TestActivityController]
+                TestWeekTemplateController, TestActivityController, TestErrorController, TestStatusController]
 ENDPOINTS = {'Account': {'/v1/Account/login': ['POST'], '/v1/Account/register': ['POST'],
                          '/v1/Account/user/{id}': ['DELETE'],
                          '/v1/User/{id}/Account/password': ['PUT', 'POST'],


### PR DESCRIPTION
This is for the missing integration tests for the web-api.
This fixes #78, fixes #27 , fixes #23 .

These tests use a package called `requests` to handle the HTTP requests.


To install the required package `requests` if you have pipenv installed run: `$ pipenv install requests`
To run the tests use the command:  `python test.py`
To show missing endpoint tests: `python test.py --missing`

Notes:
Currently the tests are missing an endpoint within the web-api.
This endpoint is the Department endpoint: /v1/Department/{departmentId}/user/{userId}, this has been made into an issue #91.
This endpoint currently does not work as no citizen can exist without a department.

Some tests currently errors on a windows machine, while they does not on a linux machine, though this may be a local problem these test is the `def test_auth_PATCH_update_activity_should_fail(self)` in ` test_authorization.py` and 5 tests from `test_user_controller.py` specifically those refering to icon's.

If the tests in `test_pictogram_controller.py` fail, it is likely because they refer to a file not created by sample data of the database, add these files to `\giraf\web-api\Pictograms` as `2.png` and `6.png`. The image must be 200x200 and of type `.png`. a placeholder can be found here: https://via.placeholder.com/200



