### PR TITLE
Fixes 96

### DIFF
--- a/GirafRest/Services/GirafService.cs
+++ b/GirafRest/Services/GirafService.cs
@@ -77,6 +77,7 @@ namespace GirafRest.Services
             var usr = (await _userManager.GetUserAsync(principal));
             if (usr == null) return null;
             return await _context.Users
+                .Where(u => u.Id == usr.Id)
                 .Include(u => u.Department)
                 .FirstOrDefaultAsync();
         }


### PR DESCRIPTION
fixes #96 
Added a line that specifies a constraint on the user ID.
Does not work on develop right now, because another PR introduced an error, where queries don't work. They are working on fixing it, as well as making tests that cover the methods used for reading pictograms, which includes the one edited in this PR.