### PR TITLE
Fix searching for Pictograms

### DIFF
--- a/GirafIntegrationTest/tests/test_pictogram_controller.py
+++ b/GirafIntegrationTest/tests/test_pictogram_controller.py
@@ -218,3 +218,15 @@ class TestPictogramController(GIRAFTestCase):
         self.assertFalse(response['success'])
         self.assertEqual(response['errorKey'], 'PictogramNotFound')
 
+    @order
+    def test_pictogram_query_(self):
+        """
+        Testing querying for a pictogram
+
+        Endpoint: GET:/v1/Pictogram?query=Epik
+        """
+        params = {'query': 'Epik', 'page': 1, 'pageSize': 10}
+        response = get(f'{BASE_URL}v1/Pictogram?query=Epik', headers=auth(citizen_token), params=params).json()
+        self.assertFalse(response['success'])
+        self.assertEqual(response['errorKey'], 'NoError')
+

--- a/GirafRest/Controllers/PictogramController.cs
+++ b/GirafRest/Controllers/PictogramController.cs
@@ -63,7 +63,7 @@ namespace GirafRest.Controllers
             if(page < 1)
                 return new ErrorResponse<List<WeekPictogramDTO>>(ErrorCode.InvalidProperties, "page");
             //Produce a list of all pictograms available to the user
-            var userPictograms = await ReadAllPictograms();
+            var userPictograms = (await ReadAllPictograms()).AsEnumerable();
             if (userPictograms == null)
                 return new ErrorResponse<List<WeekPictogramDTO>>(ErrorCode.PictogramNotFound);
 
@@ -71,7 +71,7 @@ namespace GirafRest.Controllers
             if(!String.IsNullOrEmpty(query)) 
                 userPictograms = userPictograms.OrderBy((Pictogram _p) => IbsenDistance(query, _p.Title));
 
-            return new Response<List<WeekPictogramDTO>>(await userPictograms.OfType<Pictogram>().Skip((page-1)*pageSize).Take(pageSize).Select(_p => new WeekPictogramDTO(_p)).ToListAsync());
+            return new Response<List<WeekPictogramDTO>>(userPictograms.OfType<Pictogram>().Skip((page-1)*pageSize).Take(pageSize).Select(_p => new WeekPictogramDTO(_p)).ToList());
         }
 
         /// <summary>


### PR DESCRIPTION
In #75 a change was missed.

According to the `efcore` documentation, it is no longer allowed to make a clientside query on anything else than the `Select` command
[Source](https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#linq-queries-are-no-longer-evaluated-on-the-client)

This meant that when searching for Pictograms, an exception would be thrown.

This should be fixed with this change.