### PR TITLE
Fixed being able to create users with 'æ', 'ø' and 'å'

### DIFF
--- a/GirafRest/Setup/Startup.cs
+++ b/GirafRest/Setup/Startup.cs
@@ -90,6 +90,12 @@ namespace GirafRest.Setup
             //load general configuration from appsettings.json
             services.Configure<IpRateLimitOptions>(Configuration.GetSection("IpRateLimiting"));
 
+            services.Configure<IdentityOptions>(options => {
+               // User settings.
+               options.User.AllowedUserNameCharacters =
+               "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+æøåÆØÅ";
+            }); 
+
             // inject counter and rules stores
             services.AddSingleton<IIpPolicyStore, MemoryCacheIpPolicyStore>();
             services.AddSingleton<IRateLimitCounterStore, MemoryCacheRateLimitCounterStore>();


### PR DESCRIPTION
Fixes https://github.com/aau-giraf/weekplanner/issues/467 which is an issue in the weekplanner repo, by specifying the allowed characters for a username. 
