### PR TITLE
Consistent indentation and line-ending

### DIFF
--- a/GirafRest/.editorconfig
+++ b/GirafRest/.editorconfig
@@ -1,0 +1,198 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = lf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+
+# Field preferences
+dotnet_style_readonly_field = true:suggestion
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false:silent
+csharp_style_var_for_built_in_types = false:silent
+csharp_style_var_when_type_is_apparent = false:silent
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:silent
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.capitalization = pascal_case

--- a/GirafRest/Controllers/AccountController.cs
+++ b/GirafRest/Controllers/AccountController.cs
@@ -1,23 +1,23 @@
-﻿using System.Threading.Tasks;
+﻿using GirafRest.Models;
+using GirafRest.Models.DTOs;
+using GirafRest.Models.DTOs.AccountDTOs;
+using GirafRest.Models.Responses;
+using GirafRest.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using GirafRest.Models;
-using GirafRest.Services;
-using GirafRest.Models.DTOs.AccountDTOs;
-using GirafRest.Models.DTOs;
-using System;
-using System.Linq;
 using Microsoft.EntityFrameworkCore;
-using GirafRest.Models.Responses;
-using System.Collections.Generic;
-using System.Security.Claims;
-using System.IdentityModel.Tokens.Jwt;
-using Microsoft.IdentityModel.Tokens;
-using System.Text;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using Microsoft.AspNetCore.Http;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
 
 
 namespace GirafRest.Controllers
@@ -86,7 +86,7 @@ namespace GirafRest.Controllers
                     ErrorCode.MissingProperties, "Missing password"));
 
             if (!(_giraf._context.Users.Any(u => u.UserName == model.Username)))
-                return Unauthorized(new ErrorResponse(ErrorCode.InvalidCredentials, "Invalid credentials" ));
+                return Unauthorized(new ErrorResponse(ErrorCode.InvalidCredentials, "Invalid credentials"));
 
             var result = await _signInManager.PasswordSignInAsync(model.Username, model.Password, true, lockoutOnFailure: false);
 
@@ -135,7 +135,7 @@ namespace GirafRest.Controllers
             {
                 if (!(await _authentication.HasRegisterUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User),
                                                             model.Role, model.DepartmentId.Value)))
-                    return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User has no rights", 
+                    return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User has no rights",
                         "The authenticated user does not have the rights to add user for the given department"));
             }
 
@@ -150,7 +150,7 @@ namespace GirafRest.Controllers
                 return BadRequest(new ErrorResponse(ErrorCode.DepartmentNotFound, "Department not found", "A department with the given id could not be found"));
 
             //Create a new user with the supplied information
-            var user = new GirafUser (model.Username, model.DisplayName, department, model.Role);
+            var user = new GirafUser(model.Username, model.DisplayName, department, model.Role);
 
             var result = await _giraf._userManager.CreateAsync(user, model.Password);
             if (result.Succeeded)
@@ -205,7 +205,8 @@ namespace GirafRest.Controllers
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "You do not have permission to edit this user"));
 
             var result = await _giraf._userManager.ChangePasswordAsync(user, model.OldPassword, model.NewPassword);
-            if (!result.Succeeded) {
+            if (!result.Succeeded)
+            {
                 return StatusCode(StatusCodes.Status500InternalServerError, new ErrorResponse(ErrorCode.PasswordNotUpdated, "Password was not updated"));
             }
 

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -1,17 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using GirafRest.Models;
+using GirafRest.Models.DTOs;
+using GirafRest.Models.Responses;
+using GirafRest.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
-using GirafRest.Data;
-using GirafRest.Models;
-using Microsoft.AspNetCore.Authorization;
-using GirafRest.Models.DTOs;
-using GirafRest.Services;
 using Microsoft.Extensions.Logging;
-using GirafRest.Models.Responses;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace GirafRest.Controllers
 {
@@ -57,7 +53,7 @@ namespace GirafRest.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult> PostActivity([FromBody] ActivityDTO newActivity, string userId, string weekplanName, int weekYear, int weekNumber, int weekDayNmb)
         {
-            Days weekDay = (Days) weekDayNmb;
+            Days weekDay = (Days)weekDayNmb;
             if (newActivity == null)
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "Missing new activity"));
 
@@ -127,7 +123,7 @@ namespace GirafRest.Controllers
         /// <param name="userId">an ID of the user to update activities for.</param>
         /// <returns>Returns <see cref="ActivityDTO"/> for the updated activity on success else MissingProperties or NotFound</returns>
         [HttpPatch("{userId}/update")]
-        [Authorize] 
+        [Authorize]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -145,7 +141,7 @@ namespace GirafRest.Controllers
 
             // check access rights
             if (!await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user))
-                return StatusCode(StatusCodes.Status403Forbidden,new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permissions"));
+                return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permissions"));
 
             // throws error if none of user's weeks' has the specific activity
             if (!user.WeekSchedule.Any(w => w.Weekdays.Any(wd => wd.Activities.Any(act => act.Key == activity.Id))))

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -5,6 +5,7 @@ using GirafRest.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using System.Linq;
 using System.Threading.Tasks;

--- a/GirafRest/Controllers/DepartmentController.cs
+++ b/GirafRest/Controllers/DepartmentController.cs
@@ -1,18 +1,18 @@
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+using GirafRest.Extensions;
 using GirafRest.Models;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.Extensions.Logging;
 using GirafRest.Models.DTOs;
 using GirafRest.Models.Responses;
 using GirafRest.Services;
-using Microsoft.AspNetCore.Identity;
-using GirafRest.Extensions;
-using System;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace GirafRest.Controllers
 {
@@ -68,7 +68,7 @@ namespace GirafRest.Controllers
         /// </summary>
         /// <param name="id">The id of the <see cref="Department"/> to retrieve.</param>
         /// <returns>The department as a DepartmentDTO if success else UserNotfound, NotAuthorised or NotFound</returns>
-        [HttpGet("{id}", Name="GetDepartment")]
+        [HttpGet("{id}", Name = "GetDepartment")]
         [ProducesResponseType(typeof(SuccessResponse<DepartmentDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -119,7 +119,7 @@ namespace GirafRest.Controllers
 
             var currentUser = await _giraf._userManager.GetUserAsync(HttpContext.User);
 
-            currentUser =  _giraf._context.Users.Include(a => a.Department)
+            currentUser = _giraf._context.Users.Include(a => a.Department)
                                                .FirstOrDefault(d => d.UserName == currentUser.UserName);
 
             var isSuperUser = await _giraf._userManager.IsInRoleAsync(currentUser, GirafRole.SuperUser);
@@ -212,7 +212,7 @@ namespace GirafRest.Controllers
                             .FirstOrDefaultAsync();
                         if (res == null)
                             return BadRequest(new ErrorResponse(
-                                ErrorCode.InvalidProperties, 
+                                ErrorCode.InvalidProperties,
                                 "The list of resources contained an invalid resource id: " + reso
                             ));
                         var dr = new DepartmentResource(department, res);
@@ -222,11 +222,11 @@ namespace GirafRest.Controllers
 
                 _giraf._context.Departments.Add(department);
                 _giraf._context.SaveChanges();
-                
+
                 //Create a new user with the supplied information
 
-                var departmentUser = new GirafUser(depDTO.Name, depDTO.Name, department, GirafRoles.Department) {IsDepartment = true};
-                
+                var departmentUser = new GirafUser(depDTO.Name, depDTO.Name, department, GirafRoles.Department) { IsDepartment = true };
+
                 //department.Members.Add(user);
 
                 var identityUser = await _giraf._userManager.CreateAsync(departmentUser, "0000");
@@ -275,16 +275,17 @@ namespace GirafRest.Controllers
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "Missing userId"));
 
             var currentUser = await _giraf._userManager.GetUserAsync(HttpContext.User);
-            if(currentUser == null)
+            if (currentUser == null)
                 return Unauthorized(new ErrorResponse(ErrorCode.UserNotFound, "No user logged in"));
 
             var role = await _roleManager.findUserRole(_giraf._userManager, currentUser);
 
-            if(role == GirafRoles.Department || role == GirafRoles.Guardian){
+            if (role == GirafRoles.Department || role == GirafRoles.Guardian)
+            {
                 // lets check that we are in the correct department
                 if (currentUser.DepartmentKey != departmentId)
                 {
-                    return StatusCode(StatusCodes.Status403Forbidden, 
+                    return StatusCode(StatusCodes.Status403Forbidden,
                         new ErrorResponse(ErrorCode.NotAuthorized, "Not authorized / department is incorrect"));
                 }
             }
@@ -310,7 +311,7 @@ namespace GirafRest.Controllers
 
             // only makes sense to add a guardian or citizen to a department
             if (RoleOfUserToAdd == GirafRoles.SuperUser || RoleOfUserToAdd == GirafRoles.Department)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.Forbidden, "Superusers or departments cannot be added to departments"));
 
             if (user == null)
@@ -362,7 +363,7 @@ namespace GirafRest.Controllers
 
             var resourceOwned = await _giraf.CheckPrivateOwnership(resource, usr);
             if (!resourceOwned)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not own the resource"));
 
             //Check if the department already owns the resource
@@ -419,7 +420,7 @@ namespace GirafRest.Controllers
             if (department == null)
                 return NotFound(new ErrorResponse(ErrorCode.DepartmentNotFound, "Department not found"));
 
-            if(nameDTO == null || string.IsNullOrEmpty(nameDTO.Name))
+            if (nameDTO == null || string.IsNullOrEmpty(nameDTO.Name))
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "Name is missing"));
 
             department.Name = nameDTO.Name;
@@ -490,7 +491,7 @@ namespace GirafRest.Controllers
 
             var resourceOwned = await _giraf.CheckProtectedOwnership(resource, usr);
             if (!resourceOwned)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not own resource"));
 
             //Check if the department already owns the resource and remove if so.
@@ -498,7 +499,7 @@ namespace GirafRest.Controllers
                                          .Where(dr => dr.PictogramKey == resource.Id && dr.OtherKey == department.Key)
                 .FirstOrDefaultAsync();
             if (drrelation == null)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.ResourceNotOwnedByDepartment, "Resource not owned by department"));
 
             usr.Department.Resources.Remove(drrelation);

--- a/GirafRest/Controllers/PictogramController.cs
+++ b/GirafRest/Controllers/PictogramController.cs
@@ -1,24 +1,18 @@
-using System.Linq;
-using System.Threading.Tasks;
+using GirafRest.Models;
+using GirafRest.Models.DTOs;
+using GirafRest.Models.Responses;
+using GirafRest.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using System;
-using GirafRest.Models.DTOs;
-using GirafRest.Models;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.AspNetCore.Authorization;
+using System;
 using System.Collections.Generic;
 using System.IO;
-using GirafRest.Services;
-using GirafRest.Models.Responses;
-using Microsoft.AspNetCore.Hosting;
-using System.Drawing;
-using System.Drawing.Drawing2D;
-using System.Drawing.Imaging;
-using System.Net.Mime;
-using System.Security.Cryptography;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Hosting;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace GirafRest.Controllers
 {
@@ -32,9 +26,9 @@ namespace GirafRest.Controllers
         private const string IMAGE_TYPE_PNG = "image/png";
 
         private readonly IGirafService _giraf;
-        
+
         private readonly IHostEnvironment _hostingEnvironment;
-        
+
         private readonly string imagePath;
 
         /// <summary>
@@ -43,8 +37,8 @@ namespace GirafRest.Controllers
         /// <param name="girafController">Service Injection</param>
         /// <param name="lFactory">Service Injection</param>
         /// <param name="hostingEnvironment">Service Injection</param>
-        public PictogramController(IGirafService girafController, ILoggerFactory lFactory, IHostEnvironment hostingEnvironment) 
-    {
+        public PictogramController(IGirafService girafController, ILoggerFactory lFactory, IHostEnvironment hostingEnvironment)
+        {
             _giraf = girafController;
             _giraf._logger = lFactory.CreateLogger("Pictogram");
             _hostingEnvironment = hostingEnvironment;
@@ -62,7 +56,7 @@ namespace GirafRest.Controllers
         /// <param name="pageSize">Number of pictograms per page</param>
         /// <returns> All the user's <see cref="Pictogram"/> pictograms on success else InvalidProperties or 
         /// PictogramNotFound </returns>
-        [HttpGet("", Name="GetPictograms")]
+        [HttpGet("", Name = "GetPictograms")]
         [ProducesResponseType(typeof(SuccessResponse<List<WeekPictogramDTO>>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -83,7 +77,7 @@ namespace GirafRest.Controllers
 
             return Ok(new SuccessResponse<List<WeekPictogramDTO>>(
                 userPictograms.OfType<Pictogram>()
-                .Skip((page-1)*pageSize)
+                .Skip((page - 1) * pageSize)
                 .Take(pageSize)
                 .Select(_p => new WeekPictogramDTO(_p))
                 .ToList()));
@@ -98,7 +92,7 @@ namespace GirafRest.Controllers
         /// NotFound  if no such <see cref="Pictogram"/> pictogram exists
         /// Else: PictogramNotFound, UserNotFound, Error, or NotAuthorized
         /// </returns>
-        [HttpGet("{id}", Name="GetPictogram")]
+        [HttpGet("{id}", Name = "GetPictogram")]
         [ProducesResponseType(typeof(SuccessResponse<WeekPictogramDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -132,14 +126,14 @@ namespace GirafRest.Controllers
                 if (ownsResource)
                     return Ok(new SuccessResponse<WeekPictogramDTO>(new WeekPictogramDTO(pictogram)));
                 else
-                    return StatusCode(StatusCodes.Status403Forbidden, 
+                    return StatusCode(StatusCodes.Status403Forbidden,
                         new ErrorResponse(ErrorCode.NotAuthorized, "User does not have rights to resource"));
             }
             catch (Exception e)
             {
                 var exceptionMessage = $"Exception occured in read:\n{e}";
                 _giraf._logger.LogError(exceptionMessage);
-                return StatusCode(StatusCodes.Status500InternalServerError, 
+                return StatusCode(StatusCodes.Status500InternalServerError,
                     new ErrorResponse(ErrorCode.Error, "An error happened while reading", e.Message));
             }
         }
@@ -192,8 +186,8 @@ namespace GirafRest.Controllers
             await _giraf._context.SaveChangesAsync();
 
             return CreatedAtRoute(
-                "GetPictogram", 
-                new { id = pict.Id }, 
+                "GetPictogram",
+                new { id = pict.Id },
                 new SuccessResponse<WeekPictogramDTO>(new WeekPictogramDTO(pict)));
         }
 
@@ -216,8 +210,8 @@ namespace GirafRest.Controllers
         {
             if (pictogram == null)
                 return BadRequest(
-                    new ErrorResponse(ErrorCode.MissingProperties, 
-                    "Could not read pictogram DTO.", "Please make sure not to include image data in this request. " + 
+                    new ErrorResponse(ErrorCode.MissingProperties,
+                    "Could not read pictogram DTO.", "Please make sure not to include image data in this request. " +
                     "Use POST localhost/v1/pictogram/{id}/image instead."));
             if (pictogram.AccessLevel == null)
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "Missing access level"));
@@ -225,7 +219,7 @@ namespace GirafRest.Controllers
                 return BadRequest(new ErrorResponse(ErrorCode.InvalidProperties, "Invalid model"));
 
             var usr = await _giraf.LoadBasicUserDataAsync(HttpContext.User);
-            if (usr == null) 
+            if (usr == null)
                 return Unauthorized(new ErrorResponse(ErrorCode.UserNotFound, "User not found"));
             //Fetch the pictogram from the database and check that it exists
             var pict = await _giraf._context.Pictograms
@@ -235,7 +229,7 @@ namespace GirafRest.Controllers
                 return NotFound(new ErrorResponse(ErrorCode.PictogramNotFound, "Pictogram not found"));
 
             if (!CheckOwnership(pict, usr).Result)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
             //Ensure that Id is not changed.
             pictogram.Id = id;
@@ -269,7 +263,7 @@ namespace GirafRest.Controllers
                 return NotFound(new ErrorResponse(ErrorCode.PictogramNotFound, "Pictogram not found"));
 
             if (!CheckOwnership(pict, usr).Result)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
             // Before we can remove a pictogram we must delete all its relations
@@ -323,7 +317,7 @@ namespace GirafRest.Controllers
                 return NotFound(new ErrorResponse(ErrorCode.PictogramNotFound, "Pictogram not found"));
 
             if (!CheckOwnership(pictogram, user).Result)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
             //Update the image
@@ -332,23 +326,24 @@ namespace GirafRest.Controllers
             // This sets the path that the system looks for when retrieving a pictogram
             string path = imagePath + pictogram.Id + ".png";
 
-            if (image.Length > 0){
+            if (image.Length > 0)
+            {
                 try
                 {
                     using (FileStream fs =
                     new FileStream(path,
                         FileMode.Create))
                     {
-                        
+
                         fs.Write(image);
                     }
                 }
-                catch(System.UnauthorizedAccessException uaex)
+                catch (System.UnauthorizedAccessException uaex)
                 {
                     //Consider if the errorcode is the most appropriate one here
                     return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.Forbidden, "The server does not have permission to write this file"));
                 }
-                
+
 
 
                 pictogram.ImageHash = image.GetHashCode().ToString();
@@ -380,34 +375,34 @@ namespace GirafRest.Controllers
                 return NotFound(new ErrorResponse(ErrorCode.PictogramNotFound, "Pictogram not found"));
 
             var usr = await _giraf.LoadBasicUserDataAsync(HttpContext.User);
-            if (usr == null) 
+            if (usr == null)
                 return Unauthorized(new ErrorResponse(ErrorCode.NotAuthorized, "User not authorized"));
 
             if (picto.ImageHash == null)
                 return NotFound(new ErrorResponse(ErrorCode.PictogramHasNoImage, "Pictogram has no image"));
 
             if (!CheckOwnership(picto, usr).Result)
-                return StatusCode(StatusCodes.Status403Forbidden, 
-                    new ErrorResponse(ErrorCode.NotAuthorized,  "User does not have permission"));
+                return StatusCode(StatusCodes.Status403Forbidden,
+                    new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
             var pictoPath = $"{imagePath}{picto.Id}.png";
-            
-            
+
+
             //At this time, there is no '.NET native' way to check file permissions on Linux, so instead we catch an exception, if current (OS) user does not have read permission
             try
             {
                 byte[] data = System.IO.File.ReadAllBytes(pictoPath);
                 return Ok(new SuccessResponse<byte[]>(data));
             }
-            catch(UnauthorizedAccessException uAEx)
+            catch (UnauthorizedAccessException uAEx)
             {
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "The server can not access the specified image"));
             }
-            catch(FileNotFoundException fNFex)
+            catch (FileNotFoundException fNFex)
             {
                 return StatusCode(StatusCodes.Status404NotFound, new ErrorResponse(ErrorCode.NotAuthorized, "The server can not find the specified image"));
             }
-        
+
         }
 
         /// <summary>
@@ -449,7 +444,7 @@ namespace GirafRest.Controllers
 
             // you can only get a protected picogram if it is owned by your department
             if (picto.AccessLevel == AccessLevel.PROTECTED && !picto.Departments.Any(d => d.OtherKey == usr.DepartmentKey))
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
             // you can only get a private pictogram if you are among the owners of the pictogram
@@ -471,7 +466,7 @@ namespace GirafRest.Controllers
         /// <param name="usr">The user in question.</param>
         /// <returns>A bool indicating whether the user owns the pictogram or not.</returns>
         private async Task<bool> CheckOwnership(Pictogram picto, GirafUser usr)
-        { 
+        {
             var ownsPictogram = false;
             switch (picto.AccessLevel)
             {

--- a/GirafRest/Controllers/StatusController.cs
+++ b/GirafRest/Controllers/StatusController.cs
@@ -1,10 +1,9 @@
-﻿using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using GirafRest.Models.Responses;
+﻿using GirafRest.Models.Responses;
 using GirafRest.Services;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.IO;
+using System.Linq;
 
 namespace GirafRest.Controllers
 {

--- a/GirafRest/Controllers/UserController.cs
+++ b/GirafRest/Controllers/UserController.cs
@@ -1,19 +1,19 @@
-using System.Threading.Tasks;
+using GirafRest.Extensions;
+using GirafRest.Models;
+using GirafRest.Models.DTOs;
+using GirafRest.Models.Responses;
+using GirafRest.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using GirafRest.Models;
-using GirafRest.Services;
-using System.Linq;
 using Microsoft.EntityFrameworkCore;
-using GirafRest.Models.DTOs;
-using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
 using System;
-using GirafRest.Extensions;
-using GirafRest.Models.Responses;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
-using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
 
 namespace GirafRest.Controllers
 {
@@ -44,7 +44,7 @@ namespace GirafRest.Controllers
         public UserController(
             IGirafService giraf,
             ILoggerFactory loggerFactory,
-            RoleManager<GirafRole> roleManager, 
+            RoleManager<GirafRole> roleManager,
             IAuthenticationService authentication)
         {
             _giraf = giraf;
@@ -75,7 +75,7 @@ namespace GirafRest.Controllers
         /// Find information on the user with the username supplied as a url query parameter or the current user.
         /// </summary>
         /// <returns>  Data about the user if success else MissingProperties, UserNotFound or NotAuthorized </returns>
-        [HttpGet("{id}", Name="GetUserById")]
+        [HttpGet("{id}", Name = "GetUserById")]
         [ProducesResponseType(typeof(SuccessResponse<GirafUserDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -86,7 +86,7 @@ namespace GirafRest.Controllers
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "User id not found"));
 
             //First attempt to fetch the user and check that he exists
-            var user =  _giraf._context.Users.FirstOrDefault(u => u.Id == id);
+            var user = _giraf._context.Users.FirstOrDefault(u => u.Id == id);
             if (user == null)
                 return NotFound(new ErrorResponse(ErrorCode.UserNotFound, "User not found"));
 
@@ -102,7 +102,7 @@ namespace GirafRest.Controllers
         /// </summary>
         /// <param name="id">Identifier of the <see cref="GirafUser"/> to get settings for </param>
         /// <returns> UserSettings for the user if success else MissingProperties, UserNotFound, NotAuthorized or RoleMustBeCitizien</returns>
-        [HttpGet("{id}/settings", Name="GetUserSettings")]
+        [HttpGet("{id}/settings", Name = "GetUserSettings")]
         [ProducesResponseType(typeof(SuccessResponse<GirafUserDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -123,7 +123,7 @@ namespace GirafRest.Controllers
 
             // Get the role the user is associated with
             var userRole = await _roleManager.findUserRole(_giraf._userManager, user);
-            
+
             //Returns the user settings if the user is a citizen otherwise returns an error (only citizens has settings). 
             if (userRole == GirafRoles.Citizen)
                 return Ok(new SuccessResponse<SettingDTO>(new SettingDTO(user.Settings)));
@@ -158,7 +158,7 @@ namespace GirafRest.Controllers
             // check access rights
             if (!(await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
-            
+
             // check whether user with that username already exist that does not have the same id
             if (_giraf._context.Users.Any(u => u.UserName == newUser.Username && u.Id != user.Id))
                 return Conflict(new ErrorResponse(ErrorCode.UserAlreadyExists, "Username already exists"));
@@ -183,7 +183,7 @@ namespace GirafRest.Controllers
         /// </summary>
         /// <returns>The requested image as a <see cref="ImageDTO"/></returns>
         /// <param name="id">Identifier of the <see cref="GirafUser"/>to get UserIcon for</param>
-        [HttpGet("{id}/icon", Name="GetUserIcon")]
+        [HttpGet("{id}/icon", Name = "GetUserIcon")]
         [ProducesResponseType(typeof(SuccessResponse<ImageDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public Task<ActionResult> GetUserIcon(string id)
@@ -192,7 +192,7 @@ namespace GirafRest.Controllers
             if (user == null)
                 return Task.FromResult<ActionResult>(
                     NotFound(new ErrorResponse(ErrorCode.UserNotFound, "User not found")));
-                
+
 
             if (user.UserIcon == null)
                 return Task.FromResult<ActionResult>(
@@ -244,7 +244,7 @@ namespace GirafRest.Controllers
             // check access rights
             if (!(await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
-            
+
 
             byte[] image = await _giraf.ReadRequestImage(HttpContext.Request.Body);
 
@@ -275,7 +275,7 @@ namespace GirafRest.Controllers
 
             // check access rights
             if (!(await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
             user.UserIcon = null;
@@ -333,7 +333,7 @@ namespace GirafRest.Controllers
             var curUsr = await _giraf.LoadBasicUserDataAsync(HttpContext.User);
             var resourceOwnedByCaller = await _giraf.CheckPrivateOwnership(resource, curUsr);
             if (!resourceOwnedByCaller)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not own resource"));
 
             //Check if the target user already owns the resource
@@ -374,7 +374,7 @@ namespace GirafRest.Controllers
 
             if (user == null)
                 return NotFound(new ErrorResponse(ErrorCode.UserNotFound, "User not found"));
-            
+
             //Check that valid parameters have been specified in the call
             if (resourceIdDTO == null)
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "Missing resourceIdDTO"));
@@ -387,15 +387,15 @@ namespace GirafRest.Controllers
 
             // check access rights
             if (!(await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
             //Fetch the relationship from the database and check that it exists
             var relationship = await _giraf._context.UserResources
                  .Where(ur => ur.PictogramKey == resource.Id && ur.OtherKey == user.Id)
                 .FirstOrDefaultAsync();
-            if (relationship == null) 
-                return StatusCode(StatusCodes.Status403Forbidden, 
+            if (relationship == null)
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.UserDoesNotOwnResource, "Resource is not owned by user"));
 
             //Remove the resource - both from the user's list and the database
@@ -416,8 +416,8 @@ namespace GirafRest.Controllers
         /// <returns>List of <see cref="DisplayNameDTO"/> on success else MissingProperties, NotAuthorized, Forbidden,
         /// or UserNasNoCitizens</returns>
         /// <param name="id">Identifier of the <see cref="GirafUser"/> to get citizens for</param>
-        [HttpGet("{id}/citizens", Name="GetCitizensOfUser")]
-        [Authorize (Roles = GirafRole.Department + "," + GirafRole.Guardian + "," + GirafRole.SuperUser)]
+        [HttpGet("{id}/citizens", Name = "GetCitizensOfUser")]
+        [Authorize(Roles = GirafRole.Department + "," + GirafRole.Guardian + "," + GirafRole.SuperUser)]
         [ProducesResponseType(typeof(SuccessResponse<List<DisplayNameDTO>>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -433,13 +433,13 @@ namespace GirafRest.Controllers
             // check access rights
             if (!(await _authentication.HasEditOrReadUserAccess(authUser, user)))
             {
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
             }
 
             var userRole = (await _roleManager.findUserRole(_giraf._userManager, user));
             if (userRole != GirafRoles.Guardian)
-                return StatusCode(StatusCodes.Status403Forbidden, 
+                return StatusCode(StatusCodes.Status403Forbidden,
                     new ErrorResponse(ErrorCode.Forbidden, "User does not have permission"));
 
             foreach (var citizen in user.Citizens)
@@ -451,7 +451,7 @@ namespace GirafRest.Controllers
             if (!citizens.Any())
             {
                 return NotFound(new ErrorResponse(ErrorCode.UserHasNoCitizens, "User does not have any citizens"));
-            }   
+            }
 
             return Ok(new SuccessResponse<List<DisplayNameDTO>>(citizens.ToList<DisplayNameDTO>()));
         }
@@ -462,7 +462,7 @@ namespace GirafRest.Controllers
         /// <returns>List of Guardians on success else InvalidProperties, NotAuthorized, Forbidden,
         /// or UserHasNoGuardians </returns>
         /// <param name="id">Identifier for the citizen to get guardians for</param>
-        [HttpGet("{id}/guardians", Name="GetGuardiansOfUser")]
+        [HttpGet("{id}/guardians", Name = "GetGuardiansOfUser")]
         [Authorize]
         [ProducesResponseType(typeof(SuccessResponse<List<DisplayNameDTO>>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
@@ -520,7 +520,7 @@ namespace GirafRest.Controllers
             // check access rights
             if (!(await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), guardian)))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
-                
+
 
             var citRole = _roleManager.findUserRole(_giraf._userManager, citizen).Result;
             var guaRole = _roleManager.findUserRole(_giraf._userManager, guardian).Result;
@@ -559,20 +559,20 @@ namespace GirafRest.Controllers
 
             if (user.Settings == null)
                 return NotFound(new ErrorResponse(ErrorCode.MissingSettings, "User settings not found"));
-            
+
             // check access rights
             if (!(await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
             if (!ModelState.IsValid)
                 return BadRequest(new ErrorResponse(
-                    ErrorCode.MissingProperties, 
-                    "Missing properties in model", 
-                    "Errors: " + String.Join(", ",ModelState.Values.Where(E => E.Errors.Count > 0)
+                    ErrorCode.MissingProperties,
+                    "Missing properties in model",
+                    "Errors: " + String.Join(", ", ModelState.Values.Where(E => E.Errors.Count > 0)
                         .SelectMany(e => e.Errors)
                         .Select(e => e.ErrorMessage)
                         .ToArray())));
-            
+
             if (options == null)
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "Missing settings"));
 
@@ -580,7 +580,8 @@ namespace GirafRest.Controllers
             if (error.HasValue)
                 return BadRequest(new ErrorResponse(ErrorCode.InvalidProperties, "Invalid settings"));
 
-            if(options.WeekDayColors != null) {
+            if (options.WeekDayColors != null)
+            {
                 // Validate Correct format of WeekDayColorDTOs. A color must be set for each day
                 if (options.WeekDayColors.GroupBy(d => d.Day).Any(g => g.Count() != 1))
                     return BadRequest(new ErrorResponse(ErrorCode.ColorMustHaveUniqueDay, "Colors are not set"));
@@ -618,7 +619,7 @@ namespace GirafRest.Controllers
                 !(Enum.IsDefined(typeof(CompleteMark), options.CompleteMark)) ||
                 !(Enum.IsDefined(typeof(CancelMark), options.CancelMark)) ||
                 !(Enum.IsDefined(typeof(DefaultTimer), options.DefaultTimer)) ||
-                !(Enum.IsDefined(typeof(Theme), options.Theme))) 
+                !(Enum.IsDefined(typeof(Theme), options.Theme)))
             {
                 return ErrorCode.InvalidProperties;
             }
@@ -626,7 +627,7 @@ namespace GirafRest.Controllers
             {
                 return ErrorCode.InvalidProperties;
             }
-            if (options.ActivitiesCount.HasValue && options.ActivitiesCount.Value < 1) 
+            if (options.ActivitiesCount.HasValue && options.ActivitiesCount.Value < 1)
             {
                 return ErrorCode.InvalidProperties;
             }
@@ -642,7 +643,8 @@ namespace GirafRest.Controllers
         /// <summary>
         /// // Takes a list of WeekDayColorDTOs and check if all hex given is in correct format
         /// </summary>
-        private bool IsWeekDayColorsCorrectHexFormat(SettingDTO setting){
+        private bool IsWeekDayColorsCorrectHexFormat(SettingDTO setting)
+        {
             var regex = new Regex(@"#[0-9a-fA-F]{6}");
             foreach (var weekDayColor in setting.WeekDayColors)
             {

--- a/GirafRest/Controllers/WeekController.cs
+++ b/GirafRest/Controllers/WeekController.cs
@@ -1,17 +1,16 @@
-using System;
+using GirafRest.Models;
+using GirafRest.Models.DTOs;
+using GirafRest.Models.Responses;
+using GirafRest.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using GirafRest.Models;
-using GirafRest.Models.DTOs;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using GirafRest.Services;
-using GirafRest.Models.Responses;
 using static GirafRest.Shared.SharedMethods;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.AspNetCore.Http;
 
 namespace GirafRest.Controllers
 {
@@ -43,7 +42,7 @@ namespace GirafRest.Controllers
         /// </summary>
         /// <returns>List of <see cref="WeekDTO"/> on success else UserNotFound</returns>
         /// <param name="userId">User identifier for the <see cref="GirafUser" /> to get schedules for/></param>
-        [HttpGet("v2/User/{userId}/week", Name="GetListOfWeeksExclDaysOfUser")]
+        [HttpGet("v2/User/{userId}/week", Name = "GetListOfWeeksExclDaysOfUser")]
         [Authorize]
         [ProducesResponseType(typeof(SuccessResponse<IEnumerable<WeekDTO>>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -60,7 +59,8 @@ namespace GirafRest.Controllers
             if (!user.WeekSchedule.Any())
                 return Ok(new SuccessResponse<IEnumerable<WeekDTO>>(Enumerable.Empty<WeekDTO>()));
 
-            return Ok(new SuccessResponse<IEnumerable<WeekDTO>>(user.WeekSchedule.Select(w => new WeekDTO(w) {
+            return Ok(new SuccessResponse<IEnumerable<WeekDTO>>(user.WeekSchedule.Select(w => new WeekDTO(w)
+            {
                 Days = null
             })));
         }
@@ -71,7 +71,7 @@ namespace GirafRest.Controllers
         /// </summary>
         /// <returns>List of <see cref="WeekNameDTO"/> on success else UserNotFound</returns>
         /// <param name="userId">User identifier for the <see cref="GirafUser" /> to get schedules for</param>
-        [HttpGet("v1/User/{userId}/week", Name="GetListOfWeekNamesOfUser")]
+        [HttpGet("v1/User/{userId}/week", Name = "GetListOfWeekNamesOfUser")]
         [Authorize]
         [ProducesResponseType(typeof(SuccessResponse<IEnumerable<WeekNameDTO>>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -99,7 +99,7 @@ namespace GirafRest.Controllers
         /// <param name="weekNumber">The week number of the week schedule to fetch.</param>
         /// <returns><see cref="WeekDTO"/> for the requested week on success else UserNotFound or NotAuthorized</returns>
         /// <param name="userId">Identifier of the <see cref="GirafUser"/> to request schedule for</param>
-        [HttpGet("v1/User/{userId}/week/{weekYear}/{weekNumber}", Name="GetWeekByWeekNrAndYearOfUser")]
+        [HttpGet("v1/User/{userId}/week/{weekYear}/{weekNumber}", Name = "GetWeekByWeekNrAndYearOfUser")]
         [Authorize]
         [ProducesResponseType(typeof(SuccessResponse<WeekDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -113,7 +113,7 @@ namespace GirafRest.Controllers
             // check access rightss
             if (!(await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
-            
+
             var week = user.WeekSchedule.FirstOrDefault(w => w.WeekYear == weekYear && w.WeekNumber == weekNumber);
 
             if (week != null)
@@ -129,7 +129,7 @@ namespace GirafRest.Controllers
                         }
                     }
                 }
-                
+
                 return Ok(new SuccessResponse<WeekDTO>(new WeekDTO(week)));
             }
 
@@ -142,16 +142,18 @@ namespace GirafRest.Controllers
                 await _giraf._context.SaveChangesAsync();
                 emptyThumbnail = _giraf._context.Pictograms.FirstOrDefault(r => r.Title == "default");
 
-                return Ok(new SuccessResponse<WeekDTO>(new WeekDTO() {
-                    WeekYear = weekYear, 
-                    Name = $"{weekYear} - {weekNumber}", 
-                    WeekNumber = weekNumber, 
-                    Thumbnail = new Models.DTOs.WeekPictogramDTO(emptyThumbnail), 
+                return Ok(new SuccessResponse<WeekDTO>(new WeekDTO()
+                {
+                    WeekYear = weekYear,
+                    Name = $"{weekYear} - {weekNumber}",
+                    WeekNumber = weekNumber,
+                    Thumbnail = new Models.DTOs.WeekPictogramDTO(emptyThumbnail),
                     Days = new int[] { 1, 2, 3, 4, 5, 6, 7 }
-                        .Select(d => new WeekdayDTO() { 
-                            Activities = new List<ActivityDTO>(), 
-                            Day = (Days)d 
-                        }).ToArray() 
+                        .Select(d => new WeekdayDTO()
+                        {
+                            Activities = new List<ActivityDTO>(),
+                            Day = (Days)d
+                        }).ToArray()
                 }));
             }
             emptyThumbnail = _giraf._context.Pictograms.FirstOrDefault(r => r.Title == "default");
@@ -163,9 +165,10 @@ namespace GirafRest.Controllers
                 WeekNumber = weekNumber,
                 Thumbnail = new Models.DTOs.WeekPictogramDTO(emptyThumbnail),
                 Days = new[] { 1, 2, 3, 4, 5, 6, 7 }
-                    .Select(d => new WeekdayDTO() { 
-                        Activities = new List<ActivityDTO>(), 
-                        Day = (Days)d 
+                    .Select(d => new WeekdayDTO()
+                    {
+                        Activities = new List<ActivityDTO>(),
+                        Day = (Days)d
                     }).ToArray()
             }));
         }
@@ -229,21 +232,21 @@ namespace GirafRest.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult> DeleteWeek(string userId, int weekYear, int weekNumber)
         {
-            var user =  _giraf._context.Users.Include(u => u.WeekSchedule).FirstOrDefault(u => u.Id == userId);
-            if (user == null) 
+            var user = _giraf._context.Users.Include(u => u.WeekSchedule).FirstOrDefault(u => u.Id == userId);
+            if (user == null)
                 return NotFound(new ErrorResponse(ErrorCode.UserNotFound, "User not found"));
-            
+
             // check access rightss
             if (!(await _authentication.HasEditOrReadUserAccess(await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
-            
+
             if (user.WeekSchedule.Any(w => w.WeekYear == weekYear && w.WeekNumber == weekNumber))
             {
                 var week = user.WeekSchedule.FirstOrDefault(w => w.WeekYear == weekYear && w.WeekNumber == weekNumber);
-                if (week == null) 
+                if (week == null)
                     return NotFound(new ErrorResponse(ErrorCode.NoWeekScheduleFound, "No week schedule found"));
                 user.WeekSchedule.Remove(week);
-                
+
                 await _giraf._context.SaveChangesAsync();
                 return Ok(new SuccessResponse("Deleted info for entire week"));
             }

--- a/GirafRest/Controllers/WeekTemplateController.cs
+++ b/GirafRest/Controllers/WeekTemplateController.cs
@@ -1,19 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using GirafRest.Extensions;
-using GirafRest.Models;
+﻿using GirafRest.Models;
 using GirafRest.Models.DTOs;
+using GirafRest.Models.Responses;
+using GirafRest.Services;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using GirafRest.Services;
-using GirafRest.Models.Responses;
-using Microsoft.AspNetCore.Identity;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using static GirafRest.Shared.SharedMethods;
-using Microsoft.AspNetCore.Http;
 
 namespace GirafRest.Controllers
 {
@@ -27,7 +24,7 @@ namespace GirafRest.Controllers
         /// A reference to GirafService, that contains common functionality for all controllers.
         /// </summary>
         private readonly IGirafService _giraf;
-        
+
         /// <summary>
         /// reference to the authenticationservice which provides commong authentication checks
         /// </summary>
@@ -40,8 +37,8 @@ namespace GirafRest.Controllers
         /// <param name="giraf">A reference to the GirafService.</param>
         /// <param name="loggerFactory">A reference to an implementation of ILoggerFactory. Used to create a logger.</param>
         /// <param name="authentication"></param>
-        public WeekTemplateController(IGirafService giraf, 
-            ILoggerFactory loggerFactory, 
+        public WeekTemplateController(IGirafService giraf,
+            ILoggerFactory loggerFactory,
             IAuthenticationService authentication)
         {
             _giraf = giraf;
@@ -59,18 +56,18 @@ namespace GirafRest.Controllers
         [Authorize]
         [ProducesResponseType(typeof(SuccessResponse<IEnumerable<WeekTemplateNameDTO>>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)] 
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult> GetWeekTemplates()
         {
             var user = await _giraf.LoadBasicUserDataAsync(HttpContext.User);
-            
-            if (! await _authentication.HasTemplateAccess(user))
+
+            if (!await _authentication.HasTemplateAccess(user))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
-            
+
             var result = _giraf._context.WeekTemplates
                              .Where(t => t.DepartmentKey == user.DepartmentKey)
                              .Select(w => new WeekTemplateNameDTO(w.Name, w.Id)).ToArray();
-            
+
             if (result.Length < 1)
             {
                 return NotFound(new ErrorResponse(ErrorCode.NoWeekTemplateFound, "No week template found"));
@@ -88,7 +85,7 @@ namespace GirafRest.Controllers
         /// <param name="id">The id of the week template to fetch.</param>
         /// <returns>Notfound if there is no template in the authenticated user's department by that ID,
         /// <b>or</b> if user does not have the proper authorisation for the template.</returns>
-        [HttpGet("{id}", Name="GetWeekTemplate")]
+        [HttpGet("{id}", Name = "GetWeekTemplate")]
         [Authorize]
         [ProducesResponseType(typeof(SuccessResponse<WeekTemplateDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -96,7 +93,7 @@ namespace GirafRest.Controllers
         public async Task<ActionResult> GetWeekTemplate(long id)
         {
             var user = await _giraf.LoadBasicUserDataAsync(HttpContext.User);
-            
+
             var template = await (_giraf._context.WeekTemplates
                 .Include(w => w.Thumbnail)
                 .Include(u => u.Weekdays)
@@ -108,9 +105,9 @@ namespace GirafRest.Controllers
             if (template == null)
                 return NotFound(new ErrorResponse(ErrorCode.NoWeekTemplateFound, "No week template found"));
 
-            if (! await _authentication.HasTemplateAccess(user, template?.DepartmentKey) )
+            if (!await _authentication.HasTemplateAccess(user, template?.DepartmentKey))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
-            
+
             return Ok(new SuccessResponse<WeekTemplateDTO>(new WeekTemplateDTO(template)));
         }
 
@@ -124,7 +121,7 @@ namespace GirafRest.Controllers
         /// ResourceNotFound if any pictogram id is invalid.
         /// A DTO containing the full information on the created template otherwise.</returns>
         [HttpPost("")]
-        [Authorize (Roles = GirafRole.Department + "," + GirafRole.Guardian + "," + GirafRole.SuperUser)]
+        [Authorize(Roles = GirafRole.Department + "," + GirafRole.Guardian + "," + GirafRole.SuperUser)]
         [ProducesResponseType(typeof(SuccessResponse<WeekTemplateDTO>), StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -132,17 +129,17 @@ namespace GirafRest.Controllers
         public async Task<ActionResult> CreateWeekTemplate([FromBody] WeekTemplateDTO templateDto)
         {
             var user = await _giraf.LoadBasicUserDataAsync(HttpContext.User);
-            
-            if (! await _authentication.HasTemplateAccess(user))
+
+            if (!await _authentication.HasTemplateAccess(user))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
-            if (templateDto == null) 
+            if (templateDto == null)
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "Missing templateDto"));
 
             Department department = _giraf._context.Departments.FirstOrDefault(d => d.Key == user.DepartmentKey);
             if (department == null)
                 return BadRequest(new ErrorResponse(ErrorCode.UserMustBeInDepartment, "User must be in a department"));
-            
+
             var newTemplate = new WeekTemplate(department);
 
             var errorCode = await SetWeekFromDTO(templateDto, newTemplate, _giraf);
@@ -153,7 +150,7 @@ namespace GirafRest.Controllers
             await _giraf._context.SaveChangesAsync();
             return CreatedAtRoute(
                 "GetWeekTemplate",
-                new {id = newTemplate.Id}, 
+                new { id = newTemplate.Id },
                 new SuccessResponse<WeekTemplateDTO>(new WeekTemplateDTO(newTemplate))
             );
         }
@@ -170,7 +167,7 @@ namespace GirafRest.Controllers
         /// ResourceNotFound if any pictogram id is invalid.
         /// A DTO containing the full information on the created template otherwise.</returns>
         [HttpPut("{id}")]
-        [Authorize (Roles = GirafRole.Department + "," + GirafRole.Guardian + "," + GirafRole.SuperUser)]
+        [Authorize(Roles = GirafRole.Department + "," + GirafRole.Guardian + "," + GirafRole.SuperUser)]
         [ProducesResponseType(typeof(SuccessResponse<WeekTemplateDTO>), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
@@ -179,10 +176,10 @@ namespace GirafRest.Controllers
         public async Task<ActionResult> UpdateWeekTemplate(long id, [FromBody] WeekTemplateDTO newValuesDto)
         {
             var user = await _giraf.LoadBasicUserDataAsync(HttpContext.User);
-            if (user == null) 
+            if (user == null)
                 return Unauthorized(new ErrorResponse(ErrorCode.UserNotFound, "User not found"));
 
-            if(newValuesDto == null) 
+            if (newValuesDto == null)
                 return BadRequest(new ErrorResponse(ErrorCode.MissingProperties, "Missing newValuesDto"));
 
             var template = _giraf._context.WeekTemplates
@@ -195,9 +192,9 @@ namespace GirafRest.Controllers
             if (template == null)
                 return NotFound(new ErrorResponse(ErrorCode.WeekTemplateNotFound, "Weektemplate not found"));
 
-            if (! await _authentication.HasTemplateAccess(user, template?.DepartmentKey) )
+            if (!await _authentication.HasTemplateAccess(user, template?.DepartmentKey))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
-            
+
             var errorCode = await SetWeekFromDTO(newValuesDto, template, _giraf);
             if (errorCode != null)
                 return BadRequest(errorCode);
@@ -220,11 +217,11 @@ namespace GirafRest.Controllers
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        [Authorize (Roles = GirafRole.Department + "," + GirafRole.Guardian + "," + GirafRole.SuperUser)]
+        [Authorize(Roles = GirafRole.Department + "," + GirafRole.Guardian + "," + GirafRole.SuperUser)]
         public async Task<ActionResult> DeleteTemplate(long id)
         {
             var user = await _giraf.LoadBasicUserDataAsync(HttpContext.User);
-            if (user == null) 
+            if (user == null)
                 return Unauthorized(new ErrorResponse(ErrorCode.UserNotFound, "User not found"));
 
             var template = _giraf._context.WeekTemplates
@@ -233,7 +230,7 @@ namespace GirafRest.Controllers
             if (template == null)
                 return NotFound(new ErrorResponse(ErrorCode.WeekTemplateNotFound, "Weektemplate not found"));
 
-            if (! await _authentication.HasTemplateAccess(user, template?.DepartmentKey) )
+            if (!await _authentication.HasTemplateAccess(user, template?.DepartmentKey))
                 return StatusCode(StatusCodes.Status403Forbidden, new ErrorResponse(ErrorCode.NotAuthorized, "User does not have permission"));
 
             _giraf._context.WeekTemplates.Remove(template);

--- a/GirafRest/Data/DBInitializer.cs
+++ b/GirafRest/Data/DBInitializer.cs
@@ -3,8 +3,8 @@ using GirafRest.Models;
 using Microsoft.AspNetCore.Identity;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.ComponentModel;
+using System.Linq;
 
 namespace GirafRest.Setup
 {
@@ -112,7 +112,7 @@ namespace GirafRest.Setup
                 };
 
                 var x = userManager.CreateAsync(user, sampleUser.Password).Result.Succeeded;
-                if(x)
+                if (x)
                 {
                     var a = userManager.AddToRoleAsync(user, sampleUser.Role).Result.Succeeded;
                     if (!a)

--- a/GirafRest/Data/GirafDbContext.cs
+++ b/GirafRest/Data/GirafDbContext.cs
@@ -1,12 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using GirafRest.Models;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using GirafRest.Models;
-using Microsoft.AspNetCore.Identity;
-using System.ComponentModel.DataAnnotations.Schema;
 
 #pragma warning disable 1591
 namespace GirafRest.Data
@@ -46,8 +40,8 @@ namespace GirafRest.Data
 
             //Indexes
             builder.Entity<Department>().HasIndex(dep => dep.Name).IsUnique().IsClustered();
-            builder.Entity<Pictogram>().HasIndex(pic => new {pic.Id, pic.Title}).IsUnique().IsClustered();
-            builder.Entity<Weekday>().HasIndex(day => new {day.Id}).IsUnique().IsClustered();
+            builder.Entity<Pictogram>().HasIndex(pic => new { pic.Id, pic.Title }).IsUnique().IsClustered();
+            builder.Entity<Weekday>().HasIndex(day => new { day.Id }).IsUnique().IsClustered();
             builder.Entity<Week>().HasIndex(week => week.Id).IsUnique().IsClustered();
             builder.Entity<GirafUser>().HasIndex(user => new { user.Id, user.UserName }).IsUnique().IsClustered();
 
@@ -73,7 +67,7 @@ namespace GirafRest.Data
                 .WithMany(u => u.Resources)
                 .HasForeignKey(u => u.OtherKey)
                 .OnDelete(DeleteBehavior.Cascade);
-            
+
             builder.Entity<UserResource>()
                 .HasOne(ur => ur.Pictogram)
                 .WithMany(r => r.Users)
@@ -109,7 +103,7 @@ namespace GirafRest.Data
                    .WithMany(w => w.Activities)
                 .HasForeignKey(wr => wr.OtherKey)
                 .OnDelete(DeleteBehavior.Cascade);
-            
+
             builder.Entity<Activity>()
                 .HasOne<Pictogram>(wr => wr.Pictogram)
                 .WithMany()
@@ -121,7 +115,7 @@ namespace GirafRest.Data
                 .WithMany()
                 .HasForeignKey(ac => ac.TimerKey)
                 .OnDelete(DeleteBehavior.Cascade);
-            
+
             // Configure that a citizen can have many guardians and that a citizen can have many guardians
             builder.Entity<GuardianRelation>()
                    .HasOne(gr => gr.Guardian)

--- a/GirafRest/Data/SampleDataHandler.cs
+++ b/GirafRest/Data/SampleDataHandler.cs
@@ -18,7 +18,7 @@ namespace GirafRest.Setup
             $"{Path.DirectorySeparatorChar}" +
             $"samples.json";
 
-        public SampleDataHandler(){}
+        public SampleDataHandler() { }
         public SampleDataHandler(string path)
         {
             jsonFile = path;
@@ -30,7 +30,7 @@ namespace GirafRest.Setup
             {
                 string jsonString = File.ReadAllText(jsonFile);
                 return JsonConvert.DeserializeObject<SampleData>(jsonString);
-            } 
+            }
             catch (FileNotFoundException e)
             {
                 Console.WriteLine(e.StackTrace);
@@ -158,8 +158,8 @@ namespace GirafRest.Setup
         public List<SampleDepartment> DepartmentList { get; set; }
         public List<SamplePictogram> PictogramList { get; set; }
         public List<SampleWeekday> WeekdayList { get; set; }
-        public List <SampleWeek> WeekList { get; set; }
-        public List <SampleWeekTemplate> WeekTemplateList { get; set; }
+        public List<SampleWeek> WeekList { get; set; }
+        public List<SampleWeekTemplate> WeekTemplateList { get; set; }
 
         public SampleData()
         {

--- a/GirafRest/Data/Samples/SampleWeekTemplate.cs
+++ b/GirafRest/Data/Samples/SampleWeekTemplate.cs
@@ -12,5 +12,5 @@
             ImageTitle = imageTitle;
             DepartmentName = departmentName;
         }
-    }  
+    }
 }

--- a/GirafRest/Filters/LogFilter.cs
+++ b/GirafRest/Filters/LogFilter.cs
@@ -3,11 +3,9 @@ using GirafRest.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Security.Claims;
-using System.Threading.Tasks;
 
 namespace GirafRest.Filters
 {

--- a/GirafRest/Migrations/20180510122318_initial.cs
+++ b/GirafRest/Migrations/20180510122318_initial.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using System;
-using System.Collections.Generic;
 
 namespace GirafRest.Migrations
 {

--- a/GirafRest/Migrations/20180510202914_RemoveUnusedFKs.cs
+++ b/GirafRest/Migrations/20180510202914_RemoveUnusedFKs.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace GirafRest.Migrations
 {

--- a/GirafRest/Migrations/20180511092248_RemoveUnusedFkinDepartmentResource.cs
+++ b/GirafRest/Migrations/20180511092248_RemoveUnusedFkinDepartmentResource.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace GirafRest.Migrations
 {

--- a/GirafRest/Migrations/20180517064849_MakeGirafIdUnWeekRequired.cs
+++ b/GirafRest/Migrations/20180517064849_MakeGirafIdUnWeekRequired.cs
@@ -13,7 +13,7 @@ namespace GirafRest.Migrations
         /// <param name="migrationBuilder">Which MigrationBuilder to use</param>
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-           
+
             migrationBuilder.Sql("DELETE FROM Weeks WHERE GirafUserId is NULL");
 
             migrationBuilder.DropForeignKey(name: "FK_Weeks_AspNetUsers_GirafUserId", table: "Weeks");

--- a/GirafRest/Migrations/20190417104205_RemoveImageColumn.cs
+++ b/GirafRest/Migrations/20190417104205_RemoveImageColumn.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.EntityFrameworkCore.Migrations;
-using System;
-using System.Collections.Generic;
 
 namespace GirafRest.Migrations
 {

--- a/GirafRest/Migrations/20200422122648_MakeDisplayNameInAspnetusersRequired.cs
+++ b/GirafRest/Migrations/20200422122648_MakeDisplayNameInAspnetusersRequired.cs
@@ -7,7 +7,7 @@ namespace GirafRest.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql("UPDATE aspnetusers SET DisplayName = UserName WHERE DisplayName IS NULL");
-            
+
             migrationBuilder.AlterColumn<string>(
                 name: "DisplayName",
                 table: "AspNetUsers",

--- a/GirafRest/Models/DTOs/AccountDTOs/ChangePasswordDTO.cs
+++ b/GirafRest/Models/DTOs/AccountDTOs/ChangePasswordDTO.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations;
 
 namespace GirafRest.Models.DTOs.AccountDTOs
 {

--- a/GirafRest/Models/DTOs/AccountDTOs/LoginDTO.cs
+++ b/GirafRest/Models/DTOs/AccountDTOs/LoginDTO.cs
@@ -7,7 +7,7 @@ namespace GirafRest.Models.DTOs.AccountDTOs
     /// </summary>
     public class LoginDTO
     {
-        
+
         /// <summary>
         /// The users username.
         /// </summary>

--- a/GirafRest/Models/DTOs/ActivityDTO.cs
+++ b/GirafRest/Models/DTOs/ActivityDTO.cs
@@ -47,7 +47,7 @@
         /// <summary>
         /// Empty constructor for JSON Generation
         /// </summary>
-        public ActivityDTO(){}
+        public ActivityDTO() { }
 
         /// <summary>
         /// Belonging pictogram
@@ -77,6 +77,6 @@
         /// <summary>
         /// Timer object for Activity
         /// </summary>
-        public TimerDTO Timer { get; set; } 
+        public TimerDTO Timer { get; set; }
     }
 }

--- a/GirafRest/Models/DTOs/DepartmentDTO.cs
+++ b/GirafRest/Models/DTOs/DepartmentDTO.cs
@@ -1,8 +1,8 @@
-using System.Collections.Generic;
-using System.Linq;
 using GirafRest.Extensions;
 using GirafRest.Services;
 using Microsoft.AspNetCore.Identity;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GirafRest.Models.DTOs
 {
@@ -41,14 +41,14 @@ namespace GirafRest.Models.DTOs
             Id = department.Key;
             Members = users.ToList();
             Name = department.Name;
-            
-            Resources = new List<long> (department.Resources.Select(dr => dr.PictogramKey));
+
+            Resources = new List<long>(department.Resources.Select(dr => dr.PictogramKey));
         }
 
         /// <summary>
         /// Empty constructor for JSON Generation
         /// </summary>
-        public DepartmentDTO ()
+        public DepartmentDTO()
         {
             Members = new List<DisplayNameDTO>();
             Resources = new List<long>();

--- a/GirafRest/Models/DTOs/DepartmentNameDTO.cs
+++ b/GirafRest/Models/DTOs/DepartmentNameDTO.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace GirafRest
+﻿namespace GirafRest
 {
     /// <summary>
     /// DTO for Department Name
@@ -27,6 +26,6 @@ namespace GirafRest
         /// <summary>
         /// Empty constructor for JSON Generation
         /// </summary>
-        public DepartmentNameDTO() {}
+        public DepartmentNameDTO() { }
     }
 }

--- a/GirafRest/Models/DTOs/GirafUserDTO.cs
+++ b/GirafRest/Models/DTOs/GirafUserDTO.cs
@@ -1,16 +1,12 @@
-using Microsoft.AspNetCore.Identity;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace GirafRest.Models.DTOs
 {
     /// <summary>
     /// Giraf roles
     /// </summary>
-    public enum GirafRoles {
+    public enum GirafRoles
+    {
         /// <summary>
         /// Citizen role
         /// </summary>

--- a/GirafRest/Models/DTOs/ImageDTO.cs
+++ b/GirafRest/Models/DTOs/ImageDTO.cs
@@ -26,6 +26,6 @@ namespace GirafRest.Models.DTOs
         /// <summary>
         /// DO NOT DELETE THIS! NEWTONSOFT REQUIRES AN EMPTY CONSTRUCTOR!
         /// </summary>
-        public ImageDTO() {}
+        public ImageDTO() { }
     }
 }

--- a/GirafRest/Models/DTOs/PictogramDTO.cs
+++ b/GirafRest/Models/DTOs/PictogramDTO.cs
@@ -1,6 +1,3 @@
-using System.ComponentModel.DataAnnotations;
-using System.Security.Cryptography;
-using Newtonsoft.Json;
 using System;
 
 namespace GirafRest.Models.DTOs

--- a/GirafRest/Models/DTOs/ResourceIdDTO.cs
+++ b/GirafRest/Models/DTOs/ResourceIdDTO.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace GirafRest.Models.DTOs
+﻿namespace GirafRest.Models.DTOs
 {
     /// <summary>
     /// Simple DTO for a Resource ID

--- a/GirafRest/Models/DTOs/SettingDTO.cs
+++ b/GirafRest/Models/DTOs/SettingDTO.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using GirafRest.Models;
 
 namespace GirafRest.Models.DTOs
 {
@@ -145,7 +144,7 @@ namespace GirafRest.Models.DTOs
         /// Flag for indicating whether or not timer buttons are enabled
         /// </summary>
         public bool LockTimerControl { get; set; }
-       /// <summary>
+        /// <summary>
         /// Flag for indicating whether or not pictogram text is enabled
         /// </summary>
         public bool PictogramText { get; set; }

--- a/GirafRest/Models/DTOs/TimerDTO.cs
+++ b/GirafRest/Models/DTOs/TimerDTO.cs
@@ -19,7 +19,8 @@
         /// <summary>
         /// Constructor given a Timer
         /// </summary>
-        public TimerDTO(Timer timer) { 
+        public TimerDTO(Timer timer)
+        {
             StartTime = timer.StartTime;
             Progress = timer.Progress;
             FullLength = timer.FullLength;
@@ -34,22 +35,22 @@
         /// <summary>
         /// Start time of the timers
         /// </summary>
-        public long StartTime {get; set;}
+        public long StartTime { get; set; }
 
         /// <summary>
         /// The progress of the timer in miliseconds.
         /// </summary>
-        public long Progress {get; set;}
+        public long Progress { get; set; }
 
         /// <summary>
         /// The full length of the timer.
         /// </summary>
-        public long FullLength {get; set;}
+        public long FullLength { get; set; }
 
         /// <summary>
         /// Boolean for setting whether the timer is paused.
         /// </summary>
-        public bool Paused {get; set;}
+        public bool Paused { get; set; }
 
         /// <summary>
         /// Key for Timer

--- a/GirafRest/Models/DTOs/WeekBaseDTO.cs
+++ b/GirafRest/Models/DTOs/WeekBaseDTO.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace GirafRest.Models.DTOs
 {

--- a/GirafRest/Models/DTOs/WeekDayColorDTO.cs
+++ b/GirafRest/Models/DTOs/WeekDayColorDTO.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using GirafRest.Models;
+﻿using GirafRest.Models;
 
 namespace GirafRest
 {

--- a/GirafRest/Models/DTOs/WeekNameDTO.cs
+++ b/GirafRest/Models/DTOs/WeekNameDTO.cs
@@ -1,5 +1,4 @@
-﻿using System;
-namespace GirafRest
+﻿namespace GirafRest
 {
     /// <summary>
     /// DTO for weekname, holding year, number and name

--- a/GirafRest/Models/DTOs/WeekPictogramDTO.cs
+++ b/GirafRest/Models/DTOs/WeekPictogramDTO.cs
@@ -1,10 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Threading.Tasks;
+﻿using System;
 
 namespace GirafRest.Models.DTOs
 {

--- a/GirafRest/Models/DTOs/WeekTemplateDTO.cs
+++ b/GirafRest/Models/DTOs/WeekTemplateDTO.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace GirafRest.Models.DTOs
+﻿namespace GirafRest.Models.DTOs
 {
     /// <summary>
     /// Data Transfer Object for <see cref="WeekTemplate"/>

--- a/GirafRest/Models/DTOs/WeekTemplateNameDTO.cs
+++ b/GirafRest/Models/DTOs/WeekTemplateNameDTO.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace GirafRest.Models.DTOs
+﻿namespace GirafRest.Models.DTOs
 {
     /// <summary>
     /// Data Transfer Object for <see cref="WeekTemplate"/>

--- a/GirafRest/Models/DTOs/WeekdayDTO.cs
+++ b/GirafRest/Models/DTOs/WeekdayDTO.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace GirafRest.Models.DTOs
@@ -14,24 +12,26 @@ namespace GirafRest.Models.DTOs
         /// An enum defining which day of the week this Weekday represents.
         /// </summary>
         public Days Day { get; set; }
-        
+
         /// <summary>
         /// A list of all the activities of the week.
         /// </summary>
         public ICollection<ActivityDTO> Activities { get; set; }
-        
+
         /// <summary>
         /// Creates a new data transfer object for the given week.
         /// </summary>
         /// <param name="weekday">The weekday to create a DTO for.</param>
-        public WeekdayDTO(Weekday weekday) {
+        public WeekdayDTO(Weekday weekday)
+        {
             this.Day = weekday.Day;
             Activities = new List<ActivityDTO>();
-            
-            if(weekday.Activities != null){
+
+            if (weekday.Activities != null)
+            {
                 foreach (var elem in weekday.Activities.OrderBy(a => a.Order))
                 {
-                    if(elem.Pictogram != null) Activities.Add(new ActivityDTO(elem));
+                    if (elem.Pictogram != null) Activities.Add(new ActivityDTO(elem));
                 }
             }
         }
@@ -39,6 +39,6 @@ namespace GirafRest.Models.DTOs
         /// <summary>
         /// Empty constructor required for test framework.
         /// </summary>
-        public WeekdayDTO() {}
+        public WeekdayDTO() { }
     }
 }

--- a/GirafRest/Models/Department.cs
+++ b/GirafRest/Models/Department.cs
@@ -1,8 +1,7 @@
+using GirafRest.Models.DTOs;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using GirafRest.Models.DTOs;
 
 namespace GirafRest.Models
 {
@@ -10,7 +9,8 @@ namespace GirafRest.Models
     /// Departments group users and thus have a list of users. They may own resources, that are available
     /// to all users in the department.
     /// </summary>
-    public class Department {
+    public class Department
+    {
         /// <summary>
         /// Primary key
         /// </summary>
@@ -43,7 +43,8 @@ namespace GirafRest.Models
         /// <summary>
         /// Empty contructor for JSON Generation
         /// </summary>
-        public Department () {
+        public Department()
+        {
             Members = new List<GirafUser>();
             Resources = new List<DepartmentResource>();
         }
@@ -52,7 +53,8 @@ namespace GirafRest.Models
         /// Creates a new department from the given department DTO.
         /// </summary>
         /// <param name="depDTO">The DTO containing all data on the new department.</param>
-        public Department(DepartmentDTO depDTO) : this (){
+        public Department(DepartmentDTO depDTO) : this()
+        {
             this.Name = depDTO.Name;
         }
     }

--- a/GirafRest/Models/GirafRole.cs
+++ b/GirafRest/Models/GirafRole.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace GirafRest.Models
 {

--- a/GirafRest/Models/GirafUser.cs
+++ b/GirafRest/Models/GirafUser.cs
@@ -1,10 +1,8 @@
+using GirafRest.Models.DTOs;
+using Microsoft.AspNetCore.Identity;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using GirafRest.Models.DTOs;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 
 namespace GirafRest.Models
 {
@@ -13,7 +11,7 @@ namespace GirafRest.Models
     /// </summary>
     [Table("User")]
     public class GirafUser : IdentityUser
-    {       
+    {
         /// <summary>
         /// Whether or not the current user is a DepartmentUser
         /// </summary>
@@ -78,7 +76,7 @@ namespace GirafRest.Models
             this.Citizens = new List<GuardianRelation>();
             this.Guardians = new List<GuardianRelation>();
         }
-        
+
         private void InitialiseData()
         {
             this.Settings = new Setting();
@@ -93,7 +91,8 @@ namespace GirafRest.Models
         /// Iteratr citizens for calling AddCitizen
         /// </summary>
         /// <param name="citizens"></param>
-        public void AddCitizens(List<GirafUser> citizens){
+        public void AddCitizens(List<GirafUser> citizens)
+        {
             foreach (var citizen in citizens)
             {
                 AddCitizen(citizen);
@@ -152,6 +151,6 @@ namespace GirafRest.Models
             InitialiseData();
         }
 
-       
+
     }
 }

--- a/GirafRest/Models/Many-to-Many Relationships/Activity.cs
+++ b/GirafRest/Models/Many-to-Many Relationships/Activity.cs
@@ -13,7 +13,7 @@ namespace GirafRest.Models
         /// </summary>
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public long Key {get; set;}
+        public long Key { get; set; }
 
         /// <summary>
         /// The key of the weekday to which the resource is attached.
@@ -24,7 +24,7 @@ namespace GirafRest.Models
         /// A reference to the actual weekday.
         /// </summary>
         [ForeignKey("OtherKey")]
-        public virtual Weekday Other {get; set;}
+        public virtual Weekday Other { get; set; }
 
         /// <summary>
         /// The key of the involved resource.
@@ -78,6 +78,6 @@ namespace GirafRest.Models
         /// <summary>
         /// Newtonsoft (JSON Generation) needs empty constructor. Don't delete.
         /// </summary>
-        public Activity(){}
+        public Activity() { }
     }
 }

--- a/GirafRest/Models/Many-to-Many Relationships/DepartmentResource.cs
+++ b/GirafRest/Models/Many-to-Many Relationships/DepartmentResource.cs
@@ -14,7 +14,7 @@ namespace GirafRest.Models
         /// </summary>
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public long Key {get; set;}
+        public long Key { get; set; }
 
         /// <summary>
         /// The key of the involved department.
@@ -25,7 +25,7 @@ namespace GirafRest.Models
         /// A reference to the actual department.
         /// </summary>
         [ForeignKey("OtherKey")]
-        public virtual Department Other {get; set;}
+        public virtual Department Other { get; set; }
 
         /// <summary>
         /// The key of the involved resource.
@@ -58,6 +58,6 @@ namespace GirafRest.Models
         /// <summary>
         /// DO NOT DELETE THIS!
         /// </summary>
-        public DepartmentResource(){}
+        public DepartmentResource() { }
     }
 }

--- a/GirafRest/Models/Many-to-Many Relationships/GuardianRelation.cs
+++ b/GirafRest/Models/Many-to-Many Relationships/GuardianRelation.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿using GirafRest.Models;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using GirafRest.Models;
 
 namespace GirafRest
 {

--- a/GirafRest/Models/Many-to-Many Relationships/UserResource.cs
+++ b/GirafRest/Models/Many-to-Many Relationships/UserResource.cs
@@ -14,7 +14,7 @@ namespace GirafRest.Models
         /// </summary>
         [Key]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        public long Key {get; set;}
+        public long Key { get; set; }
 
         /// <summary>
         /// The key of the user who is involved in the relationship.
@@ -25,7 +25,7 @@ namespace GirafRest.Models
         /// A reference to the actual user.
         /// </summary>
         [ForeignKey("OtherKey")]
-        public virtual GirafUser Other {get; set;}
+        public virtual GirafUser Other { get; set; }
 
         /// <summary>
         /// The key of the involved resource.
@@ -59,6 +59,6 @@ namespace GirafRest.Models
         /// <summary>
         /// DO NOT DELETE THIS.
         /// </summary>
-        public UserResource(){ }
+        public UserResource() { }
     }
 }

--- a/GirafRest/Models/Pictogram.cs
+++ b/GirafRest/Models/Pictogram.cs
@@ -1,15 +1,17 @@
+using GirafRest.Models.DTOs;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using GirafRest.Models.DTOs;
 
-namespace GirafRest.Models {
+namespace GirafRest.Models
+{
     /// <summary>
     /// A pictogram is an image with an associated title. They are used by Guardians and Citizens and so on to 
     /// communicate visually.
     /// </summary>
-    public class Pictogram {
+    public class Pictogram
+    {
         /// <summary>
         /// Pictogram title/name
         /// </summary>
@@ -60,7 +62,8 @@ namespace GirafRest.Models {
         /// <summary>
         /// Empty constructor is required by Newtonsoft.
         /// </summary>
-        public Pictogram(){
+        public Pictogram()
+        {
             Users = new List<UserResource>();
             Departments = new List<DepartmentResource>();
             LastEdit = DateTime.Now;
@@ -75,7 +78,7 @@ namespace GirafRest.Models {
             this.LastEdit = DateTime.Now;
             this.AccessLevel = (AccessLevel)other.AccessLevel;
             this.Title = other.Title;
-            if(other.ImageHash != null)
+            if (other.ImageHash != null)
                 this.ImageHash = other.ImageHash;
         }
 

--- a/GirafRest/Models/Responses/SuccessResponse.cs
+++ b/GirafRest/Models/Responses/SuccessResponse.cs
@@ -32,7 +32,7 @@ namespace GirafRest.Models.Responses
         /// Create a new sucessfull text REST response
         /// </summary>
         /// <param name="data">The data of the response</param>
-        public SuccessResponse(string data): base(data)
+        public SuccessResponse(string data) : base(data)
         { }
     }
 }

--- a/GirafRest/Models/Setting.cs
+++ b/GirafRest/Models/Setting.cs
@@ -1,10 +1,7 @@
-﻿using System;
+﻿using GirafRest.Models.DTOs;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
-using GirafRest.Models.DTOs;
-using GirafRest.Models.Responses;
 
 namespace GirafRest.Models
 {

--- a/GirafRest/Models/Timer.cs
+++ b/GirafRest/Models/Timer.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.ComponentModel.DataAnnotations;
+﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using GirafRest.Models.DTOs;
 
 namespace GirafRest.Models
 {
@@ -21,8 +19,8 @@ namespace GirafRest.Models
         /// Start time of the timer
         /// </summary>
         public long StartTime { get; set; }
-        
-        
+
+
         /// <summary>
         /// The progress of the timer in miliseconds.
         /// </summary>

--- a/GirafRest/Models/Week.cs
+++ b/GirafRest/Models/Week.cs
@@ -1,9 +1,3 @@
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using GirafRest.Models.DTOs;
-
 namespace GirafRest.Models
 {
     /// <summary>

--- a/GirafRest/Models/WeekBase.cs
+++ b/GirafRest/Models/WeekBase.cs
@@ -1,10 +1,7 @@
-﻿using GirafRest.Models.DTOs;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
-using System.Threading.Tasks;
 
 namespace GirafRest.Models
 {

--- a/GirafRest/Models/WeekDayColor.cs
+++ b/GirafRest/Models/WeekDayColor.cs
@@ -1,7 +1,6 @@
-﻿using System;
+﻿using GirafRest.Models;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using GirafRest.Models;
 
 namespace GirafRest
 {
@@ -43,7 +42,7 @@ namespace GirafRest
         /// </summary>
         public WeekDayColor()
         {
-            
+
         }
     }
 }

--- a/GirafRest/Models/WeekTemplate.cs
+++ b/GirafRest/Models/WeekTemplate.cs
@@ -1,10 +1,4 @@
-﻿using GirafRest.Models.DTOs;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace GirafRest.Models
 {
@@ -18,7 +12,7 @@ namespace GirafRest.Models
         /// </summary>
         [ForeignKey("Department")]
         public long DepartmentKey { get; set; }
-        
+
         /// <summary>
         /// A reference to the department using this template.
         /// </summary>

--- a/GirafRest/Models/Weekday.cs
+++ b/GirafRest/Models/Weekday.cs
@@ -1,16 +1,16 @@
+using GirafRest.Models.DTOs;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using GirafRest.Models.DTOs;
-using Newtonsoft.Json;
 
 namespace GirafRest.Models
 {
     /// <summary>
     /// Possible days; 1 for Monday
     /// </summary>
-    public enum Days {
+    public enum Days
+    {
         /// <summary>
         /// Monday as 1
         /// </summary>
@@ -75,7 +75,7 @@ namespace GirafRest.Models
                                             $"but {activityStates.Count} elements are in activityStates. " +
                                             $"The numbers must match.");
             }
-            
+
             this.Day = day;
             for (int i = 0; i < activityIcons.Count; i++)
             {

--- a/GirafRest/Program.cs
+++ b/GirafRest/Program.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using GirafRest.Setup;
+﻿using GirafRest.Setup;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using MySql.Data.MySqlClient;
 using Microsoft.Extensions.Logging;
+using MySql.Data.MySqlClient;
+using System;
 
 namespace GirafRest
 {
@@ -31,17 +29,20 @@ namespace GirafRest
             //Parse all the program arguments and stop execution if any invalid arguments were found.
             var pa = new ProgramArgumentParser();
             bool validArguments = pa.CheckProgramArguments(args);
-            if(!validArguments) return;
+            if (!validArguments) return;
 
             //Build the host from the given arguments.
-            try{
+            try
+            {
                 BuildWebHost(args).Run();
             }
-            catch(MySqlException e){
+            catch (MySqlException e)
+            {
                 Console.WriteLine("Something went wrong in connecting to the MySql server: " +
-                                  $"{e.Message}");              
+                                  $"{e.Message}");
             }
-            catch(Exception e){
+            catch (Exception e)
+            {
                 Console.WriteLine("Error: " + e.Message);
             }
         }
@@ -58,13 +59,13 @@ namespace GirafRest
                .UseStartup<Startup>()
                .ConfigureAppConfiguration((hostContext, config) =>
                {
-                   config.Sources.Clear();            
+                   config.Sources.Clear();
                })
                 .ConfigureLogging((hostingContext, logging) =>
                 {
                     logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
                 })
-               .UseDefaultServiceProvider(options =>options.ValidateScopes = false)
+               .UseDefaultServiceProvider(options => options.ValidateScopes = false)
                .UseApplicationInsights()
                .Build();
     }

--- a/GirafRest/ProgramArguments.cs
+++ b/GirafRest/ProgramArguments.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace GirafRest
 {
@@ -109,7 +107,7 @@ namespace GirafRest
                     + portString[0]);
             }
         }
-    
+
         /// <summary>
         /// Specifies that the server should utilize file-logging to the given file.
         /// </summary>

--- a/GirafRest/ProgramOptions.cs
+++ b/GirafRest/ProgramOptions.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace GirafRest
 {

--- a/GirafRest/Services/GirafAuthenticationService.cs
+++ b/GirafRest/Services/GirafAuthenticationService.cs
@@ -1,9 +1,9 @@
-﻿using System.Threading.Tasks;
-using GirafRest.Data;
+﻿using GirafRest.Data;
 using GirafRest.Extensions;
 using GirafRest.Models;
 using GirafRest.Models.DTOs;
 using Microsoft.AspNetCore.Identity;
+using System.Threading.Tasks;
 
 namespace GirafRest.Services
 {
@@ -50,9 +50,9 @@ namespace GirafRest.Services
         {
             if (authUser == null || userToEdit == null)
                 return false;
-            
+
             var authUserRole = await _roleManager.findUserRole(_userManager, authUser);
-            var userRole =  await _roleManager.findUserRole(_userManager, userToEdit);
+            var userRole = await _roleManager.findUserRole(_userManager, userToEdit);
 
             if (authUser.Id == userToEdit.Id)
                 return true;
@@ -98,7 +98,7 @@ namespace GirafRest.Services
 
             if (authUserRole == GirafRoles.Guardian || authUserRole == GirafRoles.Department)
             {
-                if (!(roleToAdd == GirafRoles.Guardian || roleToAdd == GirafRoles.Citizen) 
+                if (!(roleToAdd == GirafRoles.Guardian || roleToAdd == GirafRoles.Citizen)
                     && departmentKey == authUser.DepartmentKey)
                 {
                     return false;

--- a/GirafRest/Services/GirafService.cs
+++ b/GirafRest/Services/GirafService.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-using GirafRest.Data;
+﻿using GirafRest.Data;
 using GirafRest.Models;
-using GirafRest.Models.DTOs;
-using GirafRest.Models.Responses;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace GirafRest.Services
 {
@@ -21,11 +19,11 @@ namespace GirafRest.Services
         /// <summary>
         /// A reference to the database context - used to access the database and query for data. Handled by asp.net's dependency injection.
         /// </summary>
-        public GirafDbContext _context { get;  }
+        public GirafDbContext _context { get; }
         /// <summary>
         /// Asp.net's user manager. Can be used to fetch user data from the request's cookie. Handled by asp.net's dependency injection.
         /// </summary>
-        public UserManager<GirafUser> _userManager { get;  }
+        public UserManager<GirafUser> _userManager { get; }
         /// <summary>
         /// A data-logger used to write messages to the console. Handled by asp.net's dependency injection.
         /// </summary>
@@ -87,7 +85,8 @@ namespace GirafRest.Services
         /// </summary>
         /// <param name="id">id of user to load.</param>
         /// <returns>A <see cref="GirafUser"/> with <b>all</b> related data.</returns>
-        public async Task<GirafUser> LoadUserWithWeekSchedules(string id){
+        public async Task<GirafUser> LoadUserWithWeekSchedules(string id)
+        {
             var user = await _context.Users
                 //First load the user from the database
                 .Where(u => u.Id.ToLower() == id.ToLower())
@@ -113,12 +112,12 @@ namespace GirafRest.Services
         {
             if (principal == null) return null;
             var usr = (await _userManager.GetUserAsync(principal));
-            if(usr == null) return null;
+            if (usr == null) return null;
             return await _context.Users
                 //Get user by ID from database
                 .Where(u => u.Id == usr.Id)
                 //And return it
-                .FirstOrDefaultAsync();;
+                .FirstOrDefaultAsync(); ;
         }
 
         /// <summary>
@@ -140,7 +139,7 @@ namespace GirafRest.Services
                 catch (NotSupportedException)
                 {
                 }
-                
+
                 image = imageStream.ToArray();
             }
 
@@ -153,12 +152,13 @@ namespace GirafRest.Services
         /// <param name="pictogram">The pictogram to check the ownership for.</param>
         /// <param name="user"></param>
         /// <returns>True if the user is authorized to see the resource and false if not.</returns>
-        public async Task<bool> CheckPrivateOwnership(Pictogram pictogram, GirafUser user) {
+        public async Task<bool> CheckPrivateOwnership(Pictogram pictogram, GirafUser user)
+        {
             if (pictogram.AccessLevel != AccessLevel.PRIVATE)
                 return false;
 
             //The pictogram was not public, check if the user owns it.
-            if(user == null) return false;
+            if (user == null) return false;
             var ownedByUser = await _context.UserResources
                 .Where(ur => ur.PictogramKey == pictogram.Id && ur.OtherKey == user.Id)
                 .AnyAsync();
@@ -183,7 +183,7 @@ namespace GirafRest.Services
             var ownedByDepartment = await _context.DepartmentResources
                 .Where(dr => dr.PictogramKey == resource.Id && dr.OtherKey == user.Department.Key)
                 .AnyAsync();
-                
+
             return ownedByDepartment;
         }
     }

--- a/GirafRest/Services/IAuthenticationService.cs
+++ b/GirafRest/Services/IAuthenticationService.cs
@@ -1,8 +1,8 @@
-﻿using System.Threading.Tasks;
-using GirafRest.Data;
+﻿using GirafRest.Data;
 using GirafRest.Models;
 using GirafRest.Models.DTOs;
 using Microsoft.AspNetCore.Identity;
+using System.Threading.Tasks;
 
 namespace GirafRest
 {
@@ -43,7 +43,7 @@ namespace GirafRest
         /// <param name="roleToAdd">Role to add.</param>
         /// <param name="departmentKey">Department key.</param>
         Task<bool> HasRegisterUserAccess(GirafUser authUser, GirafRoles roleToAdd, long departmentKey);
-        
+
         /// <summary>
         /// Method for checking wheteher the authenticated user is allowed to edit and view templates in general. 
         /// </summary>

--- a/GirafRest/Services/IGirafService.cs
+++ b/GirafRest/Services/IGirafService.cs
@@ -1,7 +1,5 @@
 ﻿using GirafRest.Data;
 using GirafRest.Models;
-using GirafRest.Models.DTOs;
-using GirafRest.Models.Responses;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using System.IO;
@@ -37,7 +35,7 @@ namespace GirafRest.Services
         {
             get;
         }
-        
+
         /// <summary>
         /// Loads only the user with the given username, excluding any associated data.
         /// </summary>

--- a/GirafRest/Services/JwtConfig.cs
+++ b/GirafRest/Services/JwtConfig.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace GirafRest.Services
+﻿namespace GirafRest.Services
 {
     /// <summary>
     /// Instance of JwtConfig holding serverside configuration for building JWT Tokens

--- a/GirafRest/Setup/GirafExtensions.cs
+++ b/GirafRest/Setup/GirafExtensions.cs
@@ -1,32 +1,31 @@
+using GirafRest.Data;
+using GirafRest.Models;
+using GirafRest.Models.DTOs;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using GirafRest.Data;
-using Microsoft.Extensions.Configuration;
-using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.FileProviders;
-using GirafRest.Models;
-using GirafRest.Models.DTOs;
-using Microsoft.AspNetCore.Identity;
 
 namespace GirafRest.Extensions
 {
     /// <summary>
     /// The class for extension-methods for Giraf REST-api.
     /// </summary>
-    public static class GirafExtensions {
+    public static class GirafExtensions
+    {
         /// <summary>
         /// An extension-method for configuring the application to use a MySQL database.
         /// </summary>
         /// <param name="services">A reference to the services of the application.</param>
         /// <param name="Configuration">Contains the ConnectionString</param>
-        public static void AddMySql(this IServiceCollection services, IConfigurationRoot Configuration) {
+        public static void AddMySql(this IServiceCollection services, IConfigurationRoot Configuration)
+        {
             //Setup the connection to the sql server
             services.AddDbContext<GirafDbContext>(options => options.UseMySql(Configuration.GetConnectionString("DefaultConnection")));
         }
@@ -64,13 +63,13 @@ namespace GirafRest.Extensions
         /// Instance of GirafRole enum
         /// </returns>
         public static async Task<GirafRoles> findUserRole(
-            this RoleManager<GirafRole> roleManager, 
-            UserManager<GirafUser> userManager, 
+            this RoleManager<GirafRole> roleManager,
+            UserManager<GirafUser> userManager,
             GirafUser user)
         {
             GirafRoles userRole = new GirafRoles();
             var roles = await userManager.GetRolesAsync(user);
-            if(roles.Count != 0) 
+            if (roles.Count != 0)
                 userRole = (GirafRoles)Enum.Parse(typeof(GirafRoles), roles[0]);
             return userRole;
         }
@@ -79,7 +78,8 @@ namespace GirafRest.Extensions
         /// Removes the default password requirements from ASP.NET and set them to a bare minimum.
         /// </summary>
         /// <param name="options">A reference to IdentityOptions, which is used to configure Identity.</param>
-        public static void RemovePasswordRequirements(this IdentityOptions options) {
+        public static void RemovePasswordRequirements(this IdentityOptions options)
+        {
             //Set password requirements to an absolute bare minimum.
             options.Password.RequireDigit = false;
             options.Password.RequireLowercase = false;

--- a/GirafRest/Setup/Startup.cs
+++ b/GirafRest/Setup/Startup.cs
@@ -1,28 +1,28 @@
-﻿using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+﻿using AspNetCoreRateLimit;
 using GirafRest.Data;
+using GirafRest.Extensions;
+using GirafRest.Filters;
 using GirafRest.Models;
 using GirafRest.Services;
-using GirafRest.Extensions;
-using Microsoft.AspNetCore.Identity;
-using Serilog;
-using System;
-using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Serilog;
+using Swashbuckle.AspNetCore.SwaggerUI;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Text;
-using System.IdentityModel.Tokens.Jwt;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.IdentityModel.Tokens;
-using System.Collections.Generic;
-using GirafRest.Filters;
-using AspNetCoreRateLimit;
-using Swashbuckle.AspNetCore.SwaggerUI;
-using Microsoft.OpenApi.Models;
-using Microsoft.Extensions.Hosting;
+using System.Threading.Tasks;
 
 namespace GirafRest.Setup
 {
@@ -54,9 +54,12 @@ namespace GirafRest.Setup
             else
                 throw new NotSupportedException("No database option is supported by this Environment mode");
             builder.AddEnvironmentVariables();
-            try {
+            try
+            {
                 Configuration = builder.Build();
-            } catch(FileNotFoundException) {
+            }
+            catch (FileNotFoundException)
+            {
                 Console.WriteLine("ERROR: Missing appsettings file");
                 Console.WriteLine("Exiting...");
                 System.Environment.Exit(1);
@@ -128,7 +131,7 @@ namespace GirafRest.Setup
 
             // Register the Swagger generator, defining one or more Swagger documents
             services.AddSwaggerGen(c =>
-            { 
+            {
                 c.SwaggerDoc("v1", new OpenApiInfo { Title = "The Giraf REST API", Version = "v1" });
                 var basePath = AppContext.BaseDirectory;
                 var xmlPath = Path.Combine(basePath, "GirafRest.xml");
@@ -168,7 +171,8 @@ namespace GirafRest.Setup
             where T : GirafDbContext
         {
             //Add Identity for user management.
-            services.AddIdentity<GirafUser, GirafRole>(options => {
+            services.AddIdentity<GirafUser, GirafRole>(options =>
+            {
                 options.RemovePasswordRequirements();
             })
                 .AddEntityFrameworkStores<T>()
@@ -217,7 +221,7 @@ namespace GirafRest.Setup
             app.UseStaticFiles();
             // Enable Cors, see configuration in ConfigureServices
             app.UseCors("AllowAll");
-            
+
             //Tells ASP.NET to generate an HTML exception page, if an exception occurs
             if (env.IsDevelopment())
             {
@@ -241,7 +245,7 @@ namespace GirafRest.Setup
             //[Authorize] endpoint without logging in.
             app.UseMvc(routes =>
             {
-                routes.MapRoute( 
+                routes.MapRoute(
                     name: "default",
                     template: "{controller=Account}/{action=AccessDenied}");
             });
@@ -264,8 +268,8 @@ namespace GirafRest.Setup
 
             app.Run(context2 =>
             {
-              context2.Response.StatusCode = 404;
-              return Task.FromResult(0);
+                context2.Response.StatusCode = 404;
+                return Task.FromResult(0);
             });
         }
     }

--- a/GirafRest/Shared/SharedMethods.cs
+++ b/GirafRest/Shared/SharedMethods.cs
@@ -1,10 +1,10 @@
-﻿using System.Linq;
-using System.Threading.Tasks;
-using GirafRest.Models;
+﻿using GirafRest.Models;
 using GirafRest.Models.DTOs;
 using GirafRest.Models.Responses;
 using GirafRest.Services;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace GirafRest.Shared
 {
@@ -29,12 +29,12 @@ namespace GirafRest.Shared
             {
                 return new ErrorResponse(modelErrorCode.Value, "Invalid model");
             }
-            
+
             week.Name = weekDTO.Name;
-            
+
             Pictogram thumbnail = _giraf._context.Pictograms
                 .FirstOrDefault(p => p.Id == weekDTO.Thumbnail.Id);
-            if(thumbnail == null)
+            if (thumbnail == null)
                 return new ErrorResponse(ErrorCode.MissingProperties, "Missing thumbnail");
 
             week.Thumbnail = thumbnail;
@@ -67,14 +67,15 @@ namespace GirafRest.Shared
         /// <param name="to">Pictograms and choices will be added to this object.</param>
         /// <param name="from">Pictograms and choices will be read from this object.</param>
         /// <param name="_giraf">IGirafService for injection.</param>
-        private static async Task<bool> AddPictogramsToWeekday(Weekday to, WeekdayDTO from, IGirafService _giraf){
-            if(from.Activities != null) 
+        private static async Task<bool> AddPictogramsToWeekday(Weekday to, WeekdayDTO from, IGirafService _giraf)
+        {
+            if (from.Activities != null)
             {
                 foreach (var activityDTO in from.Activities)
                 {
                     var picto = await _giraf._context.Pictograms
                         .Where(p => p.Id == activityDTO.Pictogram.Id).FirstOrDefaultAsync();
-                    
+
                     if (picto != null)
                         to.Activities.Add(new Activity(to, picto, activityDTO.Order, activityDTO.State));
                 }


### PR DESCRIPTION
Added a file called .editorconfig, which defines that indentation should be with 4 spaces and line-endings should be a linefeed (LF). To enable this project-wide (web-api), code cleanup has been run. Fixes #92