### PR TITLE
Fixes 98

### DIFF
--- a/GirafRest.Test/Controllers/WeekControllerTest.cs
+++ b/GirafRest.Test/Controllers/WeekControllerTest.cs
@@ -54,7 +54,8 @@ namespace GirafRest.Test
         #region ReadWeekSchedules
 
         [Fact]
-        public void ReadWeekScheduleNames_Authenticated_Success() {
+        public void ReadWeekScheduleNames_Authenticated_Success()
+        {
             var wc = initializeTest();
             var mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
@@ -208,7 +209,8 @@ namespace GirafRest.Test
             var mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
             var tempWeek = _testContext.MockUsers[ADMIN_DEP_ONE].WeekSchedule;
-            var res = wc.UpdateWeek(mockUser.Id, 2018, 10, new WeekDTO() {
+            var res = wc.UpdateWeek(mockUser.Id, 2018, 10, new WeekDTO()
+            {
                 Thumbnail = new Models.DTOs.WeekPictogramDTO(_testContext.MockPictograms[0])
             }).Result as ObjectResult;
             var body = res.Value as ErrorResponse;
@@ -280,9 +282,9 @@ namespace GirafRest.Test
 
             var tempWeek = _testContext.MockUsers[ADMIN_DEP_ONE].WeekSchedule;
             var res = wc.UpdateWeek(
-                _testContext.MockUsers[CITIZEN_DEP_TWO].Id, 
-                2018, 
-                WEEK_ZERO, 
+                _testContext.MockUsers[CITIZEN_DEP_TWO].Id,
+                2018,
+                WEEK_ZERO,
                 new WeekDTO(week)
             ).Result as ObjectResult;
             var body = res.Value as SuccessResponse<WeekDTO>;
@@ -313,19 +315,20 @@ namespace GirafRest.Test
         }
 
         [Fact]
-        public void UpdateWeek_NewWeekValidDTO_CheckFrameNr_Success(){
+        public void UpdateWeek_NewWeekValidDTO_CheckFrameNr_Success()
+        {
             var wc = initializeTest();
             var mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
             var week = _testContext.MockUsers[ADMIN_DEP_ONE].WeekSchedule.First();
             var orderNumber = 1;
             var state = ActivityState.Active;
-            
+
             var activities = new List<Activity>()
             {
                 new Activity(week.Weekdays[0], _testContext.MockPictograms[0], orderNumber, state, null)
             };
-            
+
             week.Weekdays[0].Activities = activities;
             var res = wc.UpdateWeek(mockUser.Id, 2018, 20, new WeekDTO(week)).Result as ObjectResult;
             var body = res.Value as SuccessResponse<WeekDTO>;
@@ -337,7 +340,7 @@ namespace GirafRest.Test
 
             var getResult = wc.ReadUsersWeekSchedule(mockUser.Id, 2018, 20).Result as ObjectResult;
             var getBody = getResult.Value as SuccessResponse<WeekDTO>;
-            
+
             Assert.Equal(StatusCodes.Status200OK, getResult.StatusCode);
             Assert.Equal(orderNumber, getBody.Data.Days.ToList()[0].Activities.ToList()[0].Order);
             Assert.Equal(state, getBody.Data.Days.ToList()[0].Activities.ToList()[0].State);
@@ -349,8 +352,9 @@ namespace GirafRest.Test
             var wc = initializeTest();
             var mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
-            var res = wc.UpdateWeek(mockUser.Id, 2018, 20, new WeekDTO() { 
-                Thumbnail = new Models.DTOs.WeekPictogramDTO(_testContext.MockPictograms[0]) 
+            var res = wc.UpdateWeek(mockUser.Id, 2018, 20, new WeekDTO()
+            {
+                Thumbnail = new Models.DTOs.WeekPictogramDTO(_testContext.MockPictograms[0])
             }).Result as ObjectResult;
             var body = res.Value as ErrorResponse;
 
@@ -386,9 +390,9 @@ namespace GirafRest.Test
             var week = _testContext.MockUsers[ADMIN_DEP_ONE].WeekSchedule.First();
 
             var res = wc.UpdateWeek(
-                _testContext.MockUsers[userToEdit].Id, 
-                2018, 
-                20, 
+                _testContext.MockUsers[userToEdit].Id,
+                2018,
+                20,
                 new WeekDTO(week)
             ).Result as ObjectResult;
 
@@ -413,9 +417,9 @@ namespace GirafRest.Test
             var week = _testContext.MockUsers[ADMIN_DEP_ONE].WeekSchedule.First();
 
             var res = wc.UpdateWeek(
-                _testContext.MockUsers[userToEdit].Id, 
-                2018, 
-                20, 
+                _testContext.MockUsers[userToEdit].Id,
+                2018,
+                20,
                 new WeekDTO(week)
             ).Result as ObjectResult;
 

--- a/GirafRest.Test/Controllers/WeekControllerTest.cs
+++ b/GirafRest.Test/Controllers/WeekControllerTest.cs
@@ -24,7 +24,7 @@ namespace GirafRest.Test
 
         private const int ADMIN_DEP_ONE = 0;
         private const int GUARDIAN_DEP_TWO = 1;
-        private const int CITIZEN_DEP_TWO= 2;
+        private const int CITIZEN_DEP_TWO = 2;
         private const int DEPARTMENT_USER_DEP_TWO = 6;
         private const int CITIZEN_DEP_THREE = 3; // Have no week
         private const int WEEK_ZERO = 0;
@@ -43,7 +43,7 @@ namespace GirafRest.Test
 
             var wc = new WeekController(
                 new MockGirafService(_testContext.MockDbContext.Object,
-                                     _testContext.MockUserManager), _testContext.MockLoggerFactory.Object, 
+                                     _testContext.MockUserManager), _testContext.MockLoggerFactory.Object,
                 new GirafAuthenticationService(_testContext.MockDbContext.Object, _testContext.MockRoleManager.Object,
                                                _testContext.MockUserManager));
             _testContext.MockHttpContext = wc.MockHttpContext();
@@ -54,7 +54,7 @@ namespace GirafRest.Test
         #region ReadWeekSchedules
 
         [Fact]
-        public void ReadWeekScheduleNames_Authenticated_Success(){
+        public void ReadWeekScheduleNames_Authenticated_Success() {
             var wc = initializeTest();
             var mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
@@ -83,7 +83,7 @@ namespace GirafRest.Test
             var mockUser = _testContext.MockUsers[authUser];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
             var weekschedule = _testContext.MockWeeks[0];
-            _testContext.MockUsers[userToEdit].WeekSchedule = new List<Week>(){weekschedule};
+            _testContext.MockUsers[userToEdit].WeekSchedule = new List<Week>() { weekschedule };
             var res = wc.ReadWeekSchedules(_testContext.MockUsers[userToEdit].Id).Result as ObjectResult;
 
             var body = res.Value as ErrorResponse;
@@ -105,9 +105,9 @@ namespace GirafRest.Test
             var mockUser = _testContext.MockUsers[authUser];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
             var weekschedule = _testContext.MockWeeks[0];
-            _testContext.MockUsers[userToEdit].WeekSchedule = new List<Week>(){weekschedule};
+            _testContext.MockUsers[userToEdit].WeekSchedule = new List<Week>() { weekschedule };
             var res = wc.ReadWeekSchedules(_testContext.MockUsers[userToEdit].Id).Result as ObjectResult;
-            
+
             Assert.Equal(StatusCodes.Status200OK, res.StatusCode);
         }
 
@@ -149,7 +149,7 @@ namespace GirafRest.Test
         [InlineData(CITIZEN_DEP_TWO, GUARDIAN_DEP_TWO, ErrorCode.NotAuthorized)]
         [InlineData(CITIZEN_DEP_TWO, DEPARTMENT_USER_DEP_TWO, ErrorCode.NotAuthorized)]
         [InlineData(CITIZEN_DEP_TWO, ADMIN_DEP_ONE, ErrorCode.NotAuthorized)]
-        public void ReadWeekSchedules_CheckAuthentication_Errors(int authUser, 
+        public void ReadWeekSchedules_CheckAuthentication_Errors(int authUser,
                                                           int userToEdit, ErrorCode expectedError)
         {
             var wc = initializeTest();
@@ -162,7 +162,7 @@ namespace GirafRest.Test
             Assert.Equal(expectedError, body.ErrorCode);
         }
 
-        
+
         [Theory]
         [InlineData(ADMIN_DEP_ONE, DEPARTMENT_USER_DEP_TWO)]
         [InlineData(ADMIN_DEP_ONE, GUARDIAN_DEP_TWO)]
@@ -171,7 +171,7 @@ namespace GirafRest.Test
         [InlineData(DEPARTMENT_USER_DEP_TWO, GUARDIAN_DEP_TWO)]
         [InlineData(DEPARTMENT_USER_DEP_TWO, CITIZEN_DEP_TWO)]
         [InlineData(CITIZEN_DEP_TWO, CITIZEN_DEP_TWO)]
-        public void ReadWeekSchedules_CheckAuthentication_Success(int authUser, 
+        public void ReadWeekSchedules_CheckAuthentication_Success(int authUser,
                                                           int userToEdit)
         {
             var wc = initializeTest();
@@ -208,11 +208,11 @@ namespace GirafRest.Test
             var mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
             var tempWeek = _testContext.MockUsers[ADMIN_DEP_ONE].WeekSchedule;
-            var res = wc.UpdateWeek(mockUser.Id, 2018, 10, new WeekDTO() { 
-                Thumbnail = new Models.DTOs.WeekPictogramDTO(_testContext.MockPictograms[0]) 
+            var res = wc.UpdateWeek(mockUser.Id, 2018, 10, new WeekDTO() {
+                Thumbnail = new Models.DTOs.WeekPictogramDTO(_testContext.MockPictograms[0])
             }).Result as ObjectResult;
             var body = res.Value as ErrorResponse;
-            
+
             Assert.Equal(StatusCodes.Status400BadRequest, res.StatusCode);
             Assert.Equal(ErrorCode.InvalidAmountOfWeekdays, body.ErrorCode);
         }
@@ -240,9 +240,9 @@ namespace GirafRest.Test
 
             var tempWeek = _testContext.MockUsers[ADMIN_DEP_ONE].WeekSchedule;
             var res = wc.UpdateWeek(
-                _testContext.MockUsers[CITIZEN_DEP_THREE].Id, 
-                2018, 
-                WEEK_ZERO, 
+                _testContext.MockUsers[CITIZEN_DEP_THREE].Id,
+                2018,
+                WEEK_ZERO,
                 new WeekDTO(week)
             ).Result as ObjectResult;
             var body = res.Value as ErrorResponse;
@@ -252,6 +252,27 @@ namespace GirafRest.Test
 
             _testContext.MockUsers[ADMIN_DEP_ONE].WeekSchedule = tempWeek;
         }
+
+        [Fact]
+       // public async void UpdateWeek_AddActivityAfterTimerIsAdded()
+      /*  {
+            var wc = initializeTest();
+            var mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
+            _testContext.MockUserManager.MockLoginAsUser(mockUser);
+            _testContext.MockWeeks[0].Weekdays[0].Activities.Add(_testContext.MockActivities[0]);
+            var timer = new Timer()
+            {
+                Key = 0,
+                StartTime = 0,
+                Progress = 0,
+                FullLength = 2000,
+                Paused = true
+            };
+            _testContext.MockWeeks[0].Weekdays[0].Activities.ElementAt(0).Timer = timer;
+            var week = _testContext.MockWeeks[0];
+            await wc.UpdateWeek(mockUser.Id, 2018, 1, new WeekDTO(week));
+            Assert.Equal(_testContext.MockWeeks[0].Weekdays[0].Activities.ElementAt(0).Timer.Key, timer.Key);
+        }*/
 
         #endregion
         #region CreateWeek

--- a/GirafRest.Test/Controllers/WeekControllerTest.cs
+++ b/GirafRest.Test/Controllers/WeekControllerTest.cs
@@ -308,7 +308,7 @@ namespace GirafRest.Test
             
             var activities = new List<Activity>()
             {
-                new Activity(week.Weekdays[0], _testContext.MockPictograms[0], orderNumber, state)
+                new Activity(week.Weekdays[0], _testContext.MockPictograms[0], orderNumber, state, null)
             };
             
             week.Weekdays[0].Activities = activities;

--- a/GirafRest.Test/Controllers/WeekControllerTest.cs
+++ b/GirafRest.Test/Controllers/WeekControllerTest.cs
@@ -254,25 +254,19 @@ namespace GirafRest.Test
         }
 
         [Fact]
-       // public async void UpdateWeek_AddActivityAfterTimerIsAdded()
-      /*  {
+        public async void UpdateWeek_AddActivityAfterTimerIsAdded()
+        {
             var wc = initializeTest();
             var mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
             _testContext.MockUserManager.MockLoginAsUser(mockUser);
             _testContext.MockWeeks[0].Weekdays[0].Activities.Add(_testContext.MockActivities[0]);
-            var timer = new Timer()
-            {
-                Key = 0,
-                StartTime = 0,
-                Progress = 0,
-                FullLength = 2000,
-                Paused = true
-            };
+            var timer = _testContext.MockTimers[0];
+            long timerkey = timer.Key;
             _testContext.MockWeeks[0].Weekdays[0].Activities.ElementAt(0).Timer = timer;
             var week = _testContext.MockWeeks[0];
             await wc.UpdateWeek(mockUser.Id, 2018, 1, new WeekDTO(week));
-            Assert.Equal(_testContext.MockWeeks[0].Weekdays[0].Activities.ElementAt(0).Timer.Key, timer.Key);
-        }*/
+            Assert.Equal(_testContext.MockWeeks[0].Weekdays[0].Activities.ElementAt(0).Timer.Key, timerkey);
+        }
 
         #endregion
         #region CreateWeek

--- a/GirafRest.Test/UnitTestExtensions.cs
+++ b/GirafRest.Test/UnitTestExtensions.cs
@@ -216,16 +216,16 @@ namespace GirafRest.Test
                     if (_mockActivities == null)
                         _mockActivities = new List<Activity>()
                         {
-                            new Activity(MockWeeks[0].Weekdays[0], MockPictograms[5], 0, ActivityState.Active){
+                            new Activity(MockWeeks[0].Weekdays[0], MockPictograms[5], 0, ActivityState.Active, null){
                                 Key = 1,
                                 Order = 1,
                                 OtherKey = 1,
                                 PictogramKey = 1,
                                 State = ActivityState.Normal
                             },
-                            new Activity(MockWeeks[0].Weekdays[1], MockPictograms[6], 1, ActivityState.Canceled),
-                            new Activity(MockWeekTemplates[Template1].Weekdays[1], MockPictograms[5], 0, ActivityState.Active),
-                            new Activity(MockWeekTemplates[Template1].Weekdays[0], MockPictograms[6], 1, ActivityState.Canceled),
+                            new Activity(MockWeeks[0].Weekdays[1], MockPictograms[6], 1, ActivityState.Canceled, null),
+                            new Activity(MockWeekTemplates[Template1].Weekdays[1], MockPictograms[5], 0, ActivityState.Active, null),
+                            new Activity(MockWeekTemplates[Template1].Weekdays[0], MockPictograms[6], 1, ActivityState.Canceled, null),
                         };
 
                     return _mockActivities;

--- a/GirafRest.Test/UnitTestExtensions.cs
+++ b/GirafRest.Test/UnitTestExtensions.cs
@@ -12,7 +12,7 @@ using Microsoft.AspNetCore.Http;
 using System.IO;
 using System.Text;
 using GirafRest.Data;
-using System.Threading;
+
 
 namespace GirafRest.Test
 {
@@ -208,6 +208,31 @@ namespace GirafRest.Test
                 }
             }
 
+            private List<Timer> _mockTimers;
+            private List<Timer> MockTimers
+            {
+                get
+                {
+                    if (_mockTimers == null)
+                        _mockTimers = new List<Timer>()
+                        {
+                            new Timer()
+                            {
+                                Key = 0,
+                                StartTime = 0,
+                                Progress = 0,
+                                FullLength = 2000,
+                                Paused = true
+                            }
+                        };
+                    return _mockTimers;
+                }
+                set
+                {
+
+                }
+            }
+
             private List<Activity> _mockActivities;
             public List<Activity> MockActivities
             {
@@ -216,7 +241,7 @@ namespace GirafRest.Test
                     if (_mockActivities == null)
                         _mockActivities = new List<Activity>()
                         {
-                            new Activity(MockWeeks[0].Weekdays[0], MockPictograms[5], 0, ActivityState.Active, null){
+                            new Activity(MockWeeks[0].Weekdays[0], MockPictograms[5], 0, ActivityState.Active, MockTimers[0]){
                                 Key = 1,
                                 Order = 1,
                                 OtherKey = 1,
@@ -677,7 +702,7 @@ namespace GirafRest.Test
 
             var mockSet = new Mock<DbSet<T>>();
             mockSet.As<IAsyncEnumerable<T>>()
-                .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
+                .Setup(m => m.GetAsyncEnumerator(It.IsAny<System.Threading.CancellationToken>()))
                 .Returns(new TestDbAsyncEnumerator<T>(data.GetEnumerator()));
             
 

--- a/GirafRest.Test/UnitTestExtensions.cs
+++ b/GirafRest.Test/UnitTestExtensions.cs
@@ -209,7 +209,7 @@ namespace GirafRest.Test
             }
 
             private List<Timer> _mockTimers;
-            private List<Timer> MockTimers
+            public List<Timer> MockTimers
             {
                 get
                 {
@@ -218,8 +218,8 @@ namespace GirafRest.Test
                         {
                             new Timer()
                             {
-                                Key = 0,
-                                StartTime = 0,
+                                Key = 1,
+                                StartTime = 1589270757422,
                                 Progress = 0,
                                 FullLength = 2000,
                                 Paused = true
@@ -589,6 +589,7 @@ namespace GirafRest.Test
                 var mockRelationSet = CreateMockDbSet(MockUserResources);
                 var mockDepRes = CreateMockDbSet(MockDepartmentResources);
                 var mockActivities = CreateMockDbSet(MockActivities);
+                var mockTimers = CreateMockDbSet(MockTimers);
                 var mockDeps = CreateMockDbSet(MockDepartments);
                 //var mockPF = CreateMockDbSet(MockPictograms.Cast<PictoFrame>().ToList());
                 var mockUsers = CreateMockDbSet(MockUsers);
@@ -603,6 +604,7 @@ namespace GirafRest.Test
                 dbMock.Setup(c => c.UserResources).Returns(mockRelationSet.Object);
                 dbMock.Setup(c => c.DepartmentResources).Returns(mockDepRes.Object);
                 dbMock.Setup(c => c.Activities).Returns(mockActivities.Object);
+                dbMock.Setup(c => c.Timers).Returns(mockTimers.Object);
                 dbMock.Setup(c => c.Departments).Returns(mockDeps.Object);
                 dbMock.Setup(c => c.Weeks).Returns(mockWeeks.Object);
                 dbMock.Setup(c => c.Weekdays).Returns(mockWeekdays.Object);

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -80,7 +80,10 @@ namespace GirafRest.Controllers
             int order = dbWeekDay.Activities.Select(act => act.Order).DefaultIfEmpty(0).Max();
             order++;
 
-            Activity dbActivity = new Activity(dbWeekDay, new Pictogram() { Id = newActivity.Pictogram.Id }, order, ActivityState.Normal);
+            var picto = await _giraf._context.Pictograms
+                        .Where(p => p.Id == newActivity.Pictogram.Id).FirstOrDefaultAsync();
+            
+            Activity dbActivity = new Activity(dbWeekDay, picto, order, ActivityState.Normal, null);
             _giraf._context.Activities.Add(dbActivity);
             await _giraf._context.SaveChangesAsync();
 

--- a/GirafRest/Models/DTOs/ActivityDTO.cs
+++ b/GirafRest/Models/DTOs/ActivityDTO.cs
@@ -26,7 +26,6 @@
             this.Pictogram = new WeekPictogramDTO(weekdayResource.Pictogram);
             this.Order = weekdayResource.Order;
             this.State = weekdayResource.State;
-
             if (weekdayResource.Timer != null)
             {
                 this.Timer = new TimerDTO(weekdayResource.Timer);
@@ -42,6 +41,10 @@
             this.Order = weekdayResource.Order;
             this.State = weekdayResource.State;
             this.Pictogram = pictogram;
+            if (weekdayResource.Timer != null)
+            {
+                this.Timer = new TimerDTO(weekdayResource.Timer);
+            }
         }
 
         /// <summary>

--- a/GirafRest/Models/DTOs/TimerDTO.cs
+++ b/GirafRest/Models/DTOs/TimerDTO.cs
@@ -8,12 +8,13 @@
         /// <summary>
         /// Constructor for DTO
         /// </summary>
-        public TimerDTO(long startTime, long progress, long fullLength, bool paused)
+        public TimerDTO(long startTime, long progress, long fullLength, bool paused, long key)
         {
             StartTime = startTime;
             Progress = progress;
             FullLength = fullLength;
             Paused = paused;
+            Key = key;
         }
 
         /// <summary>
@@ -24,6 +25,7 @@
             Progress = timer.Progress;
             FullLength = timer.FullLength;
             Paused = timer.Paused;
+            Key = timer.Key;
         }
 
         /// <summary>

--- a/GirafRest/Models/Many-to-Many Relationships/Activity.cs
+++ b/GirafRest/Models/Many-to-Many Relationships/Activity.cs
@@ -66,13 +66,14 @@ namespace GirafRest.Models
         /// <param name="pictogram">The activity's pictogram.</param>
         /// <param name="order">The activity's order.</param>
         /// <param name="state">The activity's current state.</param>
-        public Activity(Weekday weekday, Pictogram pictogram, int order, ActivityState state)
+        public Activity(Weekday weekday, Pictogram pictogram, int order, ActivityState state, Timer timer)
         {
             this.Other = weekday;
             this.PictogramKey = pictogram.Id;
             this.Pictogram = pictogram;
             this.Order = order;
             this.State = state;
+            this.Timer = timer;
         }
 
         /// <summary>

--- a/GirafRest/Models/Weekday.cs
+++ b/GirafRest/Models/Weekday.cs
@@ -79,7 +79,7 @@ namespace GirafRest.Models
             this.Day = day;
             for (int i = 0; i < activityIcons.Count; i++)
             {
-                this.Activities.Add(new Activity(this, activityIcons[i], i, activityStates[i]));
+                this.Activities.Add(new Activity(this, activityIcons[i], i, activityStates[i], null));
             }
         }
 

--- a/GirafRest/Shared/SharedMethods.cs
+++ b/GirafRest/Shared/SharedMethods.cs
@@ -74,9 +74,16 @@ namespace GirafRest.Shared
                 {
                     var picto = await _giraf._context.Pictograms
                         .Where(p => p.Id == activityDTO.Pictogram.Id).FirstOrDefaultAsync();
+
+
+                    Timer timer = null;
+                    if(activityDTO.Timer != null)
+                    {
+                        timer = await _giraf._context.Timers.Where(t => t.Key == activityDTO.Timer.Key).FirstOrDefaultAsync();
+                    }
                     
                     if (picto != null)
-                        to.Activities.Add(new Activity(to, picto, activityDTO.Order, activityDTO.State));
+                        to.Activities.Add(new Activity(to, picto, activityDTO.Order, activityDTO.State, timer));
                 }
             }
             return true;


### PR DESCRIPTION
Fixes #98 
A function in Updateweek has been updated to handle timers. Timer keys has been added to several constructors to be able to send it to and from the weekplanner, to be able to identify it when updating a weekplan.
A Test to make sure this won't happen again has been added
Related to https://github.com/aau-giraf/api_client/pull/64