### PR TITLE
Fixes relative path in Swagger URL

### DIFF
--- a/GirafRest/Setup/Startup.cs
+++ b/GirafRest/Setup/Startup.cs
@@ -236,7 +236,7 @@ namespace GirafRest.Setup
             // Enable middleware to serve swagger-ui (HTML, JS, CSS, etc.), specifying the Swagger JSON endpoint.
             app.UseSwaggerUI(c =>
             {
-                c.SwaggerEndpoint("/swagger/v1/swagger.json", "Giraf REST API V1");
+                c.SwaggerEndpoint("v1/swagger.json", "Giraf REST API V1");
                 c.DocExpansion(DocExpansion.None);
             });
 


### PR DESCRIPTION
Currently, the swagger API in production lives at https://srv.giraf.cs.aau.dk/PROD/API/swagger/index.html

While before, the json-schema for api's were requested at the absolute url: `/swagger/v1/swagger.json`, which does NOT exist, as the prod/dev servers live within /PROD/API and /PROD/DEV

We need to request relative URL, to ensure that `/PROD/API/swagger` requests `/PROD/API/swagger/v1/swagger.json`