### PR TITLE
Feature/114

### DIFF
--- a/GirafRest.Test/Controllers/ActivityControllerTest.cs
+++ b/GirafRest.Test/Controllers/ActivityControllerTest.cs
@@ -152,7 +152,10 @@ namespace GirafRest.Test
      
            ActivityDTO newActivity = new ActivityDTO()
            {
-               Pictograms = new List<WeekPictogramDTO>() { new WeekPictogramDTO(new Pictogram("", AccessLevel.PUBLIC))}
+               Pictograms = new List<WeekPictogramDTO>()
+               {
+                   new WeekPictogramDTO(_testContext.MockPictograms[10])
+               }
            };
      
            var res = ac.PostActivity(

--- a/GirafRest.Test/Controllers/ActivityControllerTest.cs
+++ b/GirafRest.Test/Controllers/ActivityControllerTest.cs
@@ -130,6 +130,7 @@ namespace GirafRest.Test
             Week week = mockUser.WeekSchedule.First();
 
             ActivityDTO newActivity = null;
+            
 
             var res = ac.PostActivity(
                 newActivity, mockUser.Id, week.Name, week.WeekYear, week.WeekNumber, (int) Days.Monday
@@ -140,6 +141,29 @@ namespace GirafRest.Test
             Assert.Equal(StatusCodes.Status400BadRequest, res.StatusCode);
             Assert.Equal(ErrorCode.MissingProperties, body.ErrorCode);
         }
+
+       [Fact]
+       public void PostActivity_ValidDayInvalidDTO_InvalidProperties()
+       {
+           ActivityController ac = InitializeTest();
+           GirafUser mockUser = _testContext.MockUsers[ADMIN_DEP_ONE];
+           _testContext.MockUserManager.MockLoginAsUser(mockUser);
+           Week week = mockUser.WeekSchedule.First();
+     
+           ActivityDTO newActivity = new ActivityDTO()
+           {
+               Pictograms = new List<WeekPictogramDTO>() { new WeekPictogramDTO(new Pictogram("", AccessLevel.PUBLIC))}
+           };
+     
+           var res = ac.PostActivity(
+               newActivity, mockUser.Id, week.Name, week.WeekYear, week.WeekNumber, (int) Days.Monday
+           ).Result as ObjectResult;
+     
+           var body = res.Value as ErrorResponse;
+     
+           Assert.Equal(StatusCodes.Status400BadRequest, res.StatusCode);
+           Assert.Equal(ErrorCode.InvalidProperties, body.ErrorCode);
+       }
 
         [Fact]
         public void PostActivity_InvalidDayValidDTO_InvalidDay()

--- a/GirafRest.Test/UnitTestExtensions.cs
+++ b/GirafRest.Test/UnitTestExtensions.cs
@@ -76,6 +76,13 @@ namespace GirafRest.Test
                         new Pictogram("cat1", AccessLevel.PUBLIC) {
                             Id = 9
                         },
+                        //Do not change this Id = 10. This is used in PostActivity_ValidDayInvalidDTO_InvalidProperties()
+                        new Pictogram("", AccessLevel.PUBLIC) {
+                            Id = 10
+                        },
+                        new Pictogram("Public Picto3", AccessLevel.PUBLIC){
+                            Id = 11
+                        },
                     };
 
                     return _mockPictograms;

--- a/GirafRest.Test/UnitTestExtensions.cs
+++ b/GirafRest.Test/UnitTestExtensions.cs
@@ -75,7 +75,7 @@ namespace GirafRest.Test
                         },
                         new Pictogram("cat1", AccessLevel.PUBLIC) {
                             Id = 9
-                        }
+                        },
                     };
 
                     return _mockPictograms;

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -91,16 +91,16 @@ namespace GirafRest.Controllers
             foreach (var pictogram in newActivity.Pictograms)
             {
                 var dbPictogram = _giraf._context.Pictograms.FirstOrDefault(id => id.Id == pictogram.Id);
-                if (dbPictogram != null && dbPictogram.Title != null)
+                if (dbPictogram != null && string.IsNullOrEmpty(dbPictogram.Title))
+                {
+                    return BadRequest(new ErrorResponse(ErrorCode.InvalidProperties, "Invalid pictogram: Blank title"));
+                }
+                if (dbPictogram != null && !string.IsNullOrEmpty(dbPictogram.Title))
                 {
                     _giraf._context.PictogramRelations.Add(new PictogramRelation(
                         dbActivity, dbPictogram
                     ));
-                }
-                else if(dbPictogram != null && dbPictogram.Title == null)
-                {
-                    return NotFound(new ErrorResponse(ErrorCode.InvalidProperties, "Invalid pictogram"));
-                }
+                }               
                 else
                 {
                     return NotFound(new ErrorResponse(ErrorCode.PictogramNotFound, "Pictogram not found"));

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -91,11 +91,15 @@ namespace GirafRest.Controllers
             foreach (var pictogram in newActivity.Pictograms)
             {
                 var dbPictogram = _giraf._context.Pictograms.FirstOrDefault(id => id.Id == pictogram.Id);
-                if (dbPictogram != null)
+                if (dbPictogram != null && dbPictogram.Title != null)
                 {
                     _giraf._context.PictogramRelations.Add(new PictogramRelation(
                         dbActivity, dbPictogram
                     ));
+                }
+                else if(dbPictogram.Title == null)
+                {
+                    return NotFound(new ErrorResponse(ErrorCode.InvalidProperties, "Invalid pictogram"));
                 }
                 else
                 {

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -97,7 +97,7 @@ namespace GirafRest.Controllers
                         dbActivity, dbPictogram
                     ));
                 }
-                else if(dbPictogram.Title == null)
+                else if(dbPictogram != null && dbPictogram.Title == null)
                 {
                     return NotFound(new ErrorResponse(ErrorCode.InvalidProperties, "Invalid pictogram"));
                 }

--- a/GirafRest/Controllers/PictogramController.cs
+++ b/GirafRest/Controllers/PictogramController.cs
@@ -160,6 +160,9 @@ namespace GirafRest.Controllers
                     "Could not read pictogram DTO. Please make sure not to include image data in this request. " +
                     "Use POST localhost/v1/pictogram/{id}/image instead."));
 
+            if (string.IsNullOrEmpty(pictogram.Title))
+                return BadRequest(new ErrorResponse(ErrorCode.InvalidProperties, "Invalid pictogram: Blank title"));
+
             if (!ModelState.IsValid)
                 return BadRequest(new ErrorResponse(ErrorCode.InvalidProperties, "Model is not valid"));
 


### PR DESCRIPTION
The bug is "No exception handling when posting an activity with a pictogram with a blank title" which is not possible to reproduce with the application, but it is possible with integration testing.

We solved this by implementing a check with the string.IsNullOrEmpty function in both Pictogram- and ActivityController. This error is then handled by a BadRequest of ErrorCode type: InvalidProperties with appropriate error message.

A unit test was created for asserting BadRequest and InvalidProperties.
This test instantiates a newActivity with a new WeekPictogramDTO, which uses a MockPictograms from UnitTestExtensions.cs.
Here was a new blank title mock pictogram entry created with an of Id 10, which then was accessed with MockPictograms[10] in the ActivityControllerTest by the implemented method PostActivity_ValidDayInvalidDTO_InvalidProperties().

Closes #114 