### PR TITLE
Sorting weeks in "overståede uger"

### DIFF
--- a/GirafRest.Test/SortingWeekTest.cs
+++ b/GirafRest.Test/SortingWeekTest.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+namespace GirafRest.Test
+{
+    //This test should be moved to an apropiate location when one is defined
+    public class SortingWeekTest
+    {
+       
+
+        [Fact]
+        public void testsorting()
+        {
+            WeekNameDTO Week1 = new WeekNameDTO(2000, 2, "five");
+            WeekNameDTO Week2 = new WeekNameDTO(1999, 51, "six");
+            WeekNameDTO Week3 = new WeekNameDTO(3000, 1000, "one");
+            WeekNameDTO Week4 = new WeekNameDTO(2000, 4, "four");
+            WeekNameDTO Week5 = new WeekNameDTO(2000, 40, "two");
+            WeekNameDTO Week6 = new WeekNameDTO(2000, 7, "three");
+            
+            List<WeekNameDTO> weekList = new List<WeekNameDTO>() {Week1,Week2,Week3,Week4,Week5,Week6 };
+            weekList.Sort();
+            Assert.Collection(weekList,
+                item => Assert.Equal("one",item.Name),
+                item => Assert.Equal("two", item.Name),
+                item => Assert.Equal("three", item.Name),
+                item => Assert.Equal("four", item.Name),
+                item => Assert.Equal("five", item.Name),
+                item => Assert.Equal("six",item.Name)
+                );
+            
+
+        }
+
+    }
+}

--- a/GirafRest/Controllers/WeekController.cs
+++ b/GirafRest/Controllers/WeekController.cs
@@ -88,8 +88,11 @@ namespace GirafRest.Controllers
 
             if (!user.WeekSchedule.Any())
                 return Ok(new SuccessResponse<IEnumerable<WeekNameDTO>>(Enumerable.Empty<WeekNameDTO>()));
+            // Sort Returnlist 
+            List<WeekNameDTO> returnlist = user.WeekSchedule.Select(w => new WeekNameDTO(w.WeekYear, w.WeekNumber, w.Name)).ToList();
+            returnlist.Sort();
 
-            return Ok(new SuccessResponse<IEnumerable<WeekNameDTO>>(user.WeekSchedule.Select(w => new WeekNameDTO(w.WeekYear, w.WeekNumber, w.Name))));
+            return Ok(new SuccessResponse<IEnumerable<WeekNameDTO>>(returnlist));
         }
 
         /// <summary>

--- a/GirafRest/Models/DTOs/WeekNameDTO.cs
+++ b/GirafRest/Models/DTOs/WeekNameDTO.cs
@@ -1,9 +1,12 @@
-﻿namespace GirafRest
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace GirafRest
 {
     /// <summary>
     /// DTO for weekname, holding year, number and name
     /// </summary>
-    public class WeekNameDTO
+    public class WeekNameDTO : IComparable<WeekNameDTO>
     {
         /// <summary>
         /// A Name describing the week.
@@ -35,6 +38,19 @@
             this.Name = name;
             this.WeekYear = weekYear;
             this.WeekNumber = weekNumber;
+        }
+
+        public int CompareTo( WeekNameDTO other)
+        {
+            if (this.WeekYear.CompareTo(other.WeekYear) != 0)
+            {
+                return -1*this.WeekYear.CompareTo(other.WeekYear);
+            }else
+            {
+                return -1*this.WeekNumber.CompareTo(other.WeekNumber);
+            }
+               
+           
         }
     }
 }


### PR DESCRIPTION
# Description

Sorts weeks i "overståede uger" Newest "overståed uge" now shows first at the top instead of the list being in the order of creation.

Fixes aau-giraf/weekplanner#698

# Type of change

*Please delete options that are not relevant.*

- [x] New feature (non-breaking change which adds functionality)



# How Has This Been Tested?



The test creates a list of WeeknameDTO in an arbitrary order and is then sorted. Then the test asserts the first in the list is the newest week.


**Development Configuration**
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have Acceptance Tested this on an iOS device. 