### PR TITLE
Bug-fix 198: The type of activityId was int but should be long 

### DIFF
--- a/GirafRest.Test/Controllers/ActivityControllerTest.cs
+++ b/GirafRest.Test/Controllers/ActivityControllerTest.cs
@@ -794,16 +794,16 @@ namespace GirafRest.Test
                 }
             };
 
-            activityController.ActivityRepository.Setup(rep => rep.Get((int)activity.Key)).Returns(activity);
-            activityController.PictogramRelationRepository.Setup(rep => rep.GetWithPictogram((int)activity.Key)).Returns(pictogramRelations);
+            activityController.ActivityRepository.Setup(rep => rep.Get((long)activity.Key)).Returns(activity);
+            activityController.PictogramRelationRepository.Setup(rep => rep.GetWithPictogram((long)activity.Key)).Returns(pictogramRelations);
 
             // Act
-            ObjectResult actual = activityController.GetActivity("user1", (int)activity.Key)
+            ObjectResult actual = activityController.GetActivity("user1", (long)activity.Key)
                 .Result as ObjectResult;
 
             // Assert
-            activityController.ActivityRepository.Verify(rep => rep.Get((int)activity.Key), Times.Once);
-            activityController.PictogramRelationRepository.Verify(rep => rep.GetWithPictogram((int)activity.Key), Times.Once);
+            activityController.ActivityRepository.Verify(rep => rep.Get((long)activity.Key), Times.Once);
+            activityController.PictogramRelationRepository.Verify(rep => rep.GetWithPictogram((long)activity.Key), Times.Once);
             Assert.Equal(StatusCodes.Status200OK, actual.StatusCode);
             Assert.Equal(pictogramRelations.First().Pictogram.Title, (actual.Value as SuccessResponse<ActivityDTO>).Data.Pictograms.First().Title);
         }

--- a/GirafRest.Test/Repositories/PictogramRelationRepositoryTest.cs
+++ b/GirafRest.Test/Repositories/PictogramRelationRepositoryTest.cs
@@ -47,7 +47,7 @@ namespace GirafRest.Test.Repositories
 
     public class PictogramRelationRepositoryTest : PictogramRelationRepositoryContext
     {
-        private const int Id = 1;
+        private const long Id = 1;
         public PictogramRelationRepositoryTest()
             : base(new DbContextOptionsBuilder<GirafDbContext>()
                 .UseInMemoryDatabase(Guid.NewGuid().ToString("N")).Options)
@@ -55,7 +55,7 @@ namespace GirafRest.Test.Repositories
 
         [Theory]
         [InlineData(Id)]
-        public void GetWithPictogramTest(int id)
+        public void GetWithPictogramTest(long id)
         {
             //Arrange
             using (var context = new GirafDbContext(ContextOptions))

--- a/GirafRest/Controllers/ActivityController.cs
+++ b/GirafRest/Controllers/ActivityController.cs
@@ -204,7 +204,7 @@ namespace GirafRest.Controllers
         [HttpGet("{userId}/{activityId}")]
         [Authorize]
         [ProducesResponseType(StatusCodes.Status200OK)]
-        public async Task<ActionResult> GetActivity(string userId, int activityId)
+        public async Task<ActionResult> GetActivity(string userId, long activityId)
         {
             var activity = _activityRepository.Get(activityId);
             var pictograms = _pictogramRelationRepository.GetWithPictogram(activityId);

--- a/GirafRest/IRepositories/IRepositories M to M/IPictogramRelationRepository.cs
+++ b/GirafRest/IRepositories/IRepositories M to M/IPictogramRelationRepository.cs
@@ -8,6 +8,6 @@ namespace GirafRest.IRepositories
 {
     public interface IPictogramRelationRepository : IRepository<PictogramRelation>
     {
-        public ICollection<PictogramRelation> GetWithPictogram(int activityID);
+        public ICollection<PictogramRelation> GetWithPictogram(long activityID);
     }
 }

--- a/GirafRest/Repositories/Repositories M to M/PictogramRelationRepository.cs
+++ b/GirafRest/Repositories/Repositories M to M/PictogramRelationRepository.cs
@@ -14,7 +14,7 @@ namespace GirafRest.Repositories
 
         }
 
-        public ICollection<PictogramRelation> GetWithPictogram(int activityID)
+        public ICollection<PictogramRelation> GetWithPictogram(long activityID)
             => Context.PictogramRelations
                 .Include(pictogram => pictogram.Pictogram)
                 .Where(pr => pr.ActivityId == activityID)


### PR DESCRIPTION
# Description
The type of activityId was int but should be long 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tests has been changed to use long instead of int aswell

**Development Configuration**
* Toolchain: Android Studio
