### PR TITLE
Register trustee -  weekplanner/issues/625

### DIFF
--- a/GirafRest/Controllers/AccountController.cs
+++ b/GirafRest/Controllers/AccountController.cs
@@ -173,7 +173,7 @@ namespace GirafRest.Controllers
                             AddGuardiansToUser(user);
                             break;
                         case GirafRoles.Guardian:
-                            AddCitizensToGuardian(user);
+                            AddCitizensToUser(user);
                             break;
                         case GirafRoles.Trustee:
                             AddGuardiansToUser(user);
@@ -395,17 +395,16 @@ namespace GirafRest.Controllers
         }
         
         /// <summary>
-        /// Add citizens to registered guardian
+        /// Add citizens to registered user
         /// </summary>
-        /// <param name="guardian">The registered guardian</param>
-        private void AddCitizensToGuardian(GirafUser guardian)
+        /// <param name="user">The registered user</param>
+        private void AddCitizensToUser(GirafUser user)
         {
-            // Add a relation to all the newly created guardians citizens
             var citizens = _girafRoleRepository.GetAllCitizens();
-            var citizensInDepartment = _userRepository.GetUsersInDepartment((long)guardian.DepartmentKey, citizens);
+            var citizensInDepartment = _userRepository.GetUsersInDepartment((long)user.DepartmentKey, citizens);
             foreach (var citizen in citizensInDepartment)
             {
-                guardian.AddCitizen(citizen);
+                user.AddCitizen(citizen);
             }
         }
     }

--- a/GirafRest/Controllers/AccountController.cs
+++ b/GirafRest/Controllers/AccountController.cs
@@ -167,11 +167,18 @@ namespace GirafRest.Controllers
             {
                 if (department != null)
                 {
-                    if (model.Role == GirafRoles.Citizen)
-                        AddGuardiansToCitizens(user);
-                    else if (model.Role == GirafRoles.Guardian)
-                        AddCitizensToGuardian(user);
-                    // save changes
+                    switch (model.Role)
+                    {
+                        case GirafRoles.Citizen:
+                            AddGuardiansToUser(user);
+                            break;
+                        case GirafRoles.Guardian:
+                            AddCitizensToGuardian(user);
+                            break;
+                        case GirafRoles.Trustee:
+                            AddGuardiansToUser(user);
+                            break;
+                    }
                     _departmentRepository.Save();
                 }
                 await _signInManager.UserManager.AddToRoleAsync(user, UserRoleStr);
@@ -362,6 +369,8 @@ namespace GirafRest.Controllers
                     return GirafRole.Citizen;
                 case GirafRoles.Guardian:
                     return GirafRole.Guardian;
+                case GirafRoles.Trustee:
+                    return GirafRole.Trustee;
                 case GirafRoles.Department:
                     return GirafRole.Department;
                 case GirafRoles.SuperUser:
@@ -371,17 +380,25 @@ namespace GirafRest.Controllers
             }
         }
 
-        private void AddGuardiansToCitizens(GirafUser citizen)
+        /// <summary>
+        /// Add guardians to registered user
+        /// </summary>
+        /// <param name="user">The registered user</param>
+        private void AddGuardiansToUser(GirafUser user) //AddUserToGuardians
         {
             var guardians = _girafRoleRepository.GetAllGuardians();
-            var guardiansInDepartment = _userRepository.GetUsersInDepartment((long)citizen.DepartmentKey, guardians);
+            var guardiansInDepartment = _userRepository.GetUsersInDepartment((long)user.DepartmentKey, guardians);
             foreach (var guardian in guardiansInDepartment)
             {
-                citizen.AddGuardian(guardian);
+                user.AddGuardian(guardian);
             }
         }
-
-        private void AddCitizensToGuardian(GirafUser guardian)
+        
+        /// <summary>
+        /// Add citizens to registered guardian
+        /// </summary>
+        /// <param name="guardian">The registered guardian</param>
+        private void AddCitizensToGuardian(GirafUser guardian) //AddGuardianToCitizens
         {
             // Add a relation to all the newly created guardians citizens
             var citizens = _girafRoleRepository.GetAllCitizens();

--- a/GirafRest/Controllers/AccountController.cs
+++ b/GirafRest/Controllers/AccountController.cs
@@ -384,7 +384,7 @@ namespace GirafRest.Controllers
         /// Add guardians to registered user
         /// </summary>
         /// <param name="user">The registered user</param>
-        private void AddGuardiansToUser(GirafUser user) //AddUserToGuardians
+        private void AddGuardiansToUser(GirafUser user)
         {
             var guardians = _girafRoleRepository.GetAllGuardians();
             var guardiansInDepartment = _userRepository.GetUsersInDepartment((long)user.DepartmentKey, guardians);
@@ -398,7 +398,7 @@ namespace GirafRest.Controllers
         /// Add citizens to registered guardian
         /// </summary>
         /// <param name="guardian">The registered guardian</param>
-        private void AddCitizensToGuardian(GirafUser guardian) //AddGuardianToCitizens
+        private void AddCitizensToGuardian(GirafUser guardian)
         {
             // Add a relation to all the newly created guardians citizens
             var citizens = _girafRoleRepository.GetAllCitizens();


### PR DESCRIPTION
# Description
Enables guardian to register a trustee in the week planner (https://github.com/aau-giraf/weekplanner).

Fixes https://github.com/aau-giraf/weekplanner/issues/625

## IMPORTANT
**The pull request is related to pull request: https://github.com/aau-giraf/weekplanner/pull/879 - Please merge both**


## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests have been added to ensure that registering a guardian/trustee/citizen is handled correctly by the <code>AccountController.cs</code>.

**Development Configuration**
* Flutter version: 2.0.5
* Dart version: 2.12.3
* Dotnet-ef: 6.0.10

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas, if necessary
- [ ] I have made corresponding changes to the documentation, if necessary
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works, if necessary
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [X] I have Acceptance Tested this on an Android device
