### PR TITLE
Fixed AccountController Integration test

### DIFF
--- a/GirafRest.IntegrationTest/Tests/AccountControllerTest.cs
+++ b/GirafRest.IntegrationTest/Tests/AccountControllerTest.cs
@@ -488,7 +488,7 @@ namespace GirafRest.IntegrationTest.Tests
 
             HttpRequestMessage request = new HttpRequestMessage()
             {
-                RequestUri = new Uri($"{BASE_URL}v1/User/{await TestExtension.GetUserIdAsync(_factory, _accountFixture.GuardianUsername, _accountFixture.Password)}"),
+                RequestUri = new Uri($"{BASE_URL}v1/user/{await TestExtension.GetUserIdAsync(_factory, _accountFixture.GuardianUsername, _accountFixture.Password)}"),
                 Method = HttpMethod.Get
             };
 
@@ -499,7 +499,7 @@ namespace GirafRest.IntegrationTest.Tests
             var content = JObject.Parse(await response.Content.ReadAsStringAsync());
 
             Assert.Equal(System.Net.HttpStatusCode.Forbidden, response.StatusCode);
-            Assert.Equal("NotAuthorized", content["errorKey"].ToString());
+            Assert.Equal("Forbidden", content["errorKey"].ToString());
         }
 
         /// <summary>

--- a/GirafRest/Controllers/UserController.cs
+++ b/GirafRest/Controllers/UserController.cs
@@ -130,7 +130,7 @@ namespace GirafRest.Controllers
             if (user == null)
                 return NotFound(new ErrorResponse(ErrorCode.UserNotFound, "User not found"));
 
-
+            //Checks if user has proper authorization to get another user.
             if (!(await _authentication.HasEditOrReadUserAccess(
                 await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
                 return new ForbidResult();

--- a/GirafRest/Controllers/UserController.cs
+++ b/GirafRest/Controllers/UserController.cs
@@ -34,6 +34,7 @@ namespace GirafRest.Controllers
         private readonly IUserResourseRepository _userResourseRepository;
         private readonly IPictogramRepository _pictogramRepository;
         private readonly RoleManager<GirafRole> _roleManager;
+        private readonly IAuthenticationService _authentication;
 
         /// <summary>
         /// Constructor for UserController
@@ -45,6 +46,7 @@ namespace GirafRest.Controllers
         /// <param name="imageRepository">Service Injection</param>
         /// <param name="userResourceRepository">Service Injection</param>
         /// <param name="pictogramRepository">Service Injection</param>
+        /// <param name="authentication"></param>
         public UserController(
             IGirafService giraf,
             ILoggerFactory loggerFactory,
@@ -52,7 +54,8 @@ namespace GirafRest.Controllers
             IGirafUserRepository girafUserRepository, 
             IImageRepository imageRepository, 
             IUserResourseRepository userResourceRepository, 
-            IPictogramRepository pictogramRepository)
+            IPictogramRepository pictogramRepository, 
+            IAuthenticationService authentication)
         {
             _giraf = giraf;
             _giraf._logger = loggerFactory.CreateLogger("User");
@@ -61,6 +64,7 @@ namespace GirafRest.Controllers
             _imageRepository = imageRepository;
             _userResourseRepository = userResourceRepository;
             _pictogramRepository = pictogramRepository;
+            _authentication = authentication;
         }
 
         /// <summary>
@@ -126,8 +130,11 @@ namespace GirafRest.Controllers
             if (user == null)
                 return NotFound(new ErrorResponse(ErrorCode.UserNotFound, "User not found"));
 
-          
-           
+
+            if (!(await _authentication.HasEditOrReadUserAccess(
+                await _giraf._userManager.GetUserAsync(HttpContext.User), user)))
+                return new ForbidResult();
+
             return Ok(new SuccessResponse<GirafUserDTO>(new GirafUserDTO(user, await _roleManager.findUserRole(_giraf._userManager, user))));
         }
 


### PR DESCRIPTION
# Description
The `AccountController` integration test failed because the `UserController` was missing request handling, which previously existed, but was removed in a refactor in pr#241. We assume that they forgot to re-add the request handling. This has been added and works on my machine. 

Fixes #279 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
The integration tests were run locally. This was done in both the feature branch and in the develop branch to see that no other tests would start failing.


**Development Configuration**
* Dotnet version: 6.0.401

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [x] I have made corresponding changes to the documentation, if necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [ ] I have Acceptance Tested this on an Android device
