### PR TITLE
Task/311

### DIFF
--- a/GirafRest.IntegrationTest/GirafRest.IntegrationTest.csproj
+++ b/GirafRest.IntegrationTest/GirafRest.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.7.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">

--- a/GirafRest.Test/GirafRest.Test.csproj
+++ b/GirafRest.Test/GirafRest.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 

--- a/GirafRest/GirafRest.csproj
+++ b/GirafRest/GirafRest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 6 and .NET-EF 6, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and .NET-EF 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF Core 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF6, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and .NET-EF 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF Core 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:


### PR DESCRIPTION
# Description

Update from .NET 6 to .NET 8.0.100-rc.1.23463.5 (only specified as net8.0 in the csproj, should work when full release is available)

All 3 projects have been changed to .NET 8.


Fixes #311 

## Type of change

- [ x ] This change requires a documentation update

# How Has This Been Tested?

All unit tests and integrations tests passes on Ubuntu 22.04, and Macos ventura 13.6, appsettings.development.json was changed to a local db instance during testing. 

However there are some exceptions thrown only to the terminal regarding middleware during the integrationtests. However these exception are also prevalent on the development branch, so these are not from the SDK update.


