### PR TITLE
Task/311

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up API
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0'
+          dotnet-version: '8.0.100-rc.1.23463.5'
       - name: Run API
         # secrets are located in repo aau-giraf/web-api:settings.secrets
         # "nohup" is used to run the dotnet application in the background 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up API
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
       - name: Run API
         # secrets are located in repo aau-giraf/web-api:settings.secrets
         # "nohup" is used to run the dotnet application in the background 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0'
+        dotnet-version: '8.0'
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Tests

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '8.0'
+        dotnet-version: '8.0.100-rc.1.23463.5'
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Using microsoft .NET 6.0 software development kit as 
 # the build envionment.
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
 # Copy the project to the container
@@ -12,7 +12,7 @@ RUN dotnet publish -c Release -o out
 #------------------------------------------#
 
 # Use microsoft ASP.NET 6.0 as the runtime envionment
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime-env
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime-env
 WORKDIR /srv
 
 # COPY the built files from the build environment into a local container

--- a/GirafRest.IntegrationTest/GirafRest.IntegrationTest.csproj
+++ b/GirafRest.IntegrationTest/GirafRest.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.7.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">

--- a/GirafRest.Test/GirafRest.Test.csproj
+++ b/GirafRest.Test/GirafRest.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 

--- a/GirafRest/GirafRest.csproj
+++ b/GirafRest/GirafRest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 6 and .NET-EF 6, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and .NET-EF 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF Core 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF6, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and .NET-EF 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF Core 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:


### PR DESCRIPTION
# Description

Update from .NET 6 to .NET 8 RC, the update required Microsoft.AspNetCore.Mvc.Testing to be updated to a newer version, updated to 7.0.11.

The first complete release of .NET 8 will be in November 2023 and is the new LTS version.

The dockerfile and more specifically the workflow files for the unit and integration test have been changed to the specific .NET 8 RC version, this should be changed to .NET 8.0, when its released.

Fixes #311

## Type of change
- [ X ] This change requires a documentation update

# How Has This Been Tested?

The API has been run and tested on Ubuntu 22.04, and macOS ventura 13.6. All unit tests and integration tests passes. 

However during the integration testing an exception is thrown, it does not affect the tests, this "error" is also present on the development branch, and is deemed to not be related to the SDK update. 

