### PR TITLE
task/317

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up API
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '8.0'
+          dotnet-version: '8.0.100-rc.1.23463.5'
       - name: Run API
         # secrets are located in repo aau-giraf/web-api:settings.secrets
         # "nohup" is used to run the dotnet application in the background 

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up API
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '6.0'
+          dotnet-version: '8.0'
       - name: Run API
         # secrets are located in repo aau-giraf/web-api:settings.secrets
         # "nohup" is used to run the dotnet application in the background 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '6.0'
+        dotnet-version: '8.0'
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Tests

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '8.0'
+        dotnet-version: '8.0.100-rc.1.23463.5'
     - name: Build with dotnet
       run: dotnet build --configuration Release
     - name: Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Using microsoft .NET 6.0 software development kit as 
 # the build envionment.
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
 # Copy the project to the container
@@ -12,7 +12,7 @@ RUN dotnet publish -c Release -o out
 #------------------------------------------#
 
 # Use microsoft ASP.NET 6.0 as the runtime envionment
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime-env
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime-env
 WORKDIR /srv
 
 # COPY the built files from the build environment into a local container

--- a/GirafRest.IntegrationTest/GirafRest.IntegrationTest.csproj
+++ b/GirafRest.IntegrationTest/GirafRest.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.7.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.1.8">

--- a/GirafRest.Test/GirafRest.Test.csproj
+++ b/GirafRest.Test/GirafRest.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
 

--- a/GirafRest/GirafRest.csproj
+++ b/GirafRest/GirafRest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <PropertyGroup>

--- a/GirafRest/GirafRest.csproj
+++ b/GirafRest/GirafRest.csproj
@@ -45,9 +45,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
+    <PackageReference Include="SkiaSharp" Version="2.88.6" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="2.88.6" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.2" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
     <PackageReference Include="AspNetCoreRateLimit" Version="4.0.2" />
   </ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 6 and .NET-EF 6, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and .NET-EF 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF Core 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF6, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web-api
 This repository contains the REST API which the weekplanner uses to connect with the database through, here the web-api, server and database make out the backend of the project.
 
-The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and .NET-EF 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
+The web-api is written as a .NET project and it is therefore written in C#. The current version of the project is .NET 8 and EF Core 8, and it is not compatible with newer versions of these frameworks. The project consists of different controllers with endpoints for the requests made by the client, repositories for accessing the database through and models, which translates into the different entities/tables that are in the database.
 
 # Branches
 This repository uses the scaled trunkbased branching strategy, as explained here: [Github setup](https://github.com/aau-giraf/.github/blob/main/wiki/about/github.md). In this repository the "trunk" is named develop, and this is the branch that all developers should branch from when solving an issue. The naming convention for these branches are:


### PR DESCRIPTION
# Description
#311 should be merged before this pull request is reviewed.

As described in issue #317 Microsoft have classified the GDI+ API (which `System.Drawing.Common` uses) as windows only and even on Windows it is obsolete and not recommended for new projects. The Unix implementation is [lacking in functionality and is largely untested](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only#reason-for-change); they recommend migrating to alternative drawing libraries, which this pull request implements, namely the SkiaSharp library.

This means that the pictogram generation can function without any external dependencies now, as SkiaSharp is entirely installed through a NuGet package, with no other external dependencies. 

This change required a re-write of the functions that generate pictograms to utilize the SkiaSharp API rather than System.Drawing.Common, similarly one of the integration tests relied on functionality incompatible with SkiaSharp, as such it was rewritten to function properly once more.

The font used to generate the pictograms is also changed to the default typeface of the machine the program is running on, to prevent any issues with font families not being available and pictograms turning out entirely white with no text.

Fixes #317 

**I am unsure of this should be merged into the branch `task/311` which this originally branches from or if it should be merged into `develop` as the change itself has nothing to do with what issue #311 originally set out to resolve.**

**The reason this branch branched from `task/311` instead of `develop` is because one of the [suggested fixes](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only#recommended-action) by Microsoft was essentially a hack specific to .NET 6.0, and to prevent this from becoming an accepted solution (as it would not actually fix the underlying problem) I moved to a branch with a .NET version that would not support this solution.**

## Type of change
- [x] This change requires a documentation update
    - Specifically, the [linux setup guide prerequisites](https://github.com/aau-giraf/.github/blob/main/wiki/setup-guide/linux_setup.md#prerequisites) section point 5 about additional libraries and the [mac setup guide prerequisites](https://github.com/aau-giraf/.github/blob/main/wiki/setup-guide/mac_setup.md#prerequisites) section 6 about additional libraries will no longer be required. [This dockerfile](https://github.com/aau-giraf/.github/blob/main/docker-giraf/web-api/Dockerfile) used for a containerised setup can also remove the installation of `libgdiplus` and `libc6-dev` as they are no longer required; it is also possible that the `libglu1-mesa` package is no longer required, as it relates to the OpenGL drawing API, which theoretically should no longer be used by the program, however I have not confirmed this.

# How Has This Been Tested?
All unit tests and integrations tests work. Nothing regarding communication with the frontend is affected by this proposed change, as the generation of pictograms is entirely irrelevant to the frontend - therefore nothing has been tested in the frontend.

The change has been tested on:
- Linux Kernel 6.1.54 with NixOS 23.11pre527133.5ba549eafcf3 (Tapir) x86_64, without having installed `libgdiplus` or `libc6-dev`.
- MacOS 14.0, without having installed `mono-libgdiplus`.

**Development Configuration**
* Dotnet version: 8.0.100-preview.5.23303.2

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas, if necessary
- [x] I have made corresponding changes to the documentation, if necessary
    - Nothing inside this repository requires documentation changes, however the setup guide changes and dockerfile changes mentioned above should be made if this PR is accepted.
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works, if necessary
    - As this is a rewrite new tests have not been added, but previous tests pass and the one test that required changes to fit the new changes also passes.
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have Acceptance Tested this on an iOS device
- [ ] I have Acceptance Tested this on an Android device
