### PR TITLE
Task/333 - Clean up terminal prints on application startup

### DIFF
--- a/GirafRest/Controllers/StatusController.cs
+++ b/GirafRest/Controllers/StatusController.cs
@@ -40,7 +40,6 @@ namespace GirafRest.Controllers
         [ProducesResponseType(typeof(SuccessResponse), StatusCodes.Status200OK)]
         public ActionResult Status()
         {
-            Console.WriteLine("return ok on status");
             return Ok(new SuccessResponse("GIRAF API is running!"));
         }
 

--- a/GirafRest/Program.cs
+++ b/GirafRest/Program.cs
@@ -67,10 +67,10 @@ namespace GirafRest
                 .ConfigureLogging((hostingContext, logging) =>
                 {
                     logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+                    logging.SetMinimumLevel(LogLevel.Warning);
                 })
                .UseDefaultServiceProvider(options => options.ValidateScopes = false)
                .Build();
-            
         }
        
     }

--- a/GirafRest/Program.cs
+++ b/GirafRest/Program.cs
@@ -24,7 +24,7 @@ namespace GirafRest
         /// <param name="args">program arguments</param>
         public static void Main(string[] args)
         {
-            Console.WriteLine("Welcome to Giraf REST Server.");
+            Console.WriteLine("Welcome to Giraf REST Server. :-)");
 
             //Parse all the program arguments and stop execution if any invalid arguments were found.
             var pa = new ProgramArgumentParser();
@@ -35,8 +35,6 @@ namespace GirafRest
             try
             {
                 BuildWebHost(args).Run();
-                Console.WriteLine("webhost built");
-                
             }
             catch (MySqlException e)
             {

--- a/GirafRest/appsettings.Development.json
+++ b/GirafRest/appsettings.Development.json
@@ -5,7 +5,8 @@
     "Logging": {
         "IncludeScopes": false,
         "LogLevel": {
-            "Default": "Warning"
+          "Default": "Error",
+          "Microsoft.AspNetCore": "Error"
         }
     },
     "Email": {


### PR DESCRIPTION
# Description

Removes unnecessary prints done to the console when running the web-api, by reducing the amount of logging done in the application. 

Fixes #333 

# Definition of Done

- [x] When only important settings used to launch the server are printed in the terminal.
    - Now only warnings are shown in the console, which have high relevance in a development environment.