### PR TITLE
Remove CI on push

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -2,7 +2,8 @@
 name: Docker push
 
 on:
-  push:
+  pull_request:
+    branches: ["develop", "Release"]
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,7 +1,8 @@
 name: Integration Test
 
 on:
-  push:
+  pull_request:
+    branches: ["develop", "Release"]
 jobs:
   build:
     name: Integration Test

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,7 +1,8 @@
 name: Unit Test
 
 on:
-  push:
+  pull_request:
+    branches: ["develop", "Release"]
 jobs:
   build:
     name: Unit Test


### PR DESCRIPTION
Stop Github Actions being run at every single push, and instead only run on pull requests to Develop and Release. 