### PR TITLE
Change docker-compose port to avoid conflict

### DIFF
--- a/GirafRest/appsettings.LocalDocker.json
+++ b/GirafRest/appsettings.LocalDocker.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "server=db;port=3306;userid=local;password=Giraf123;database=giraf;"
+    "DefaultConnection": "server=db;port=5001;userid=local;password=Giraf123;database=giraf;"
   },
   "Logging": {
     "IncludeScopes": false,

--- a/GirafRest/appsettings.LocalDocker.json
+++ b/GirafRest/appsettings.LocalDocker.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "server=db;port=5001;userid=local;password=Giraf123;database=giraf;"
+    "DefaultConnection": "server=db;port=3306;userid=local;password=Giraf123;database=giraf;"
   },
   "Logging": {
     "IncludeScopes": false,

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ In the terminal write the command: `docker compose up -d`
 
 The Docker compose will setup the database and seed it with sample data before starting the web-api.
 
+**The database can be accessed from port 5100**
+
 You can confirm the web-api is running by going to the [swagger endpoint](http://localhost:5000/swagger).
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       interval: 1s
       retries: 120
     ports:  
-      - 5001:5001
+      - 5001:3306
     volumes:
       - db_data:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   db:
     container_name: GirafMysqlDatabase
     image: mysql
-    restart: always
+    restart: on-failure
     environment:
       MYSQL_DATABASE: 'giraf'
       MYSQL_USER: 'local'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       interval: 1s
       retries: 120
     ports:  
-      - 5001:3306
+      - 5100:3306
     volumes:
       - db_data:/var/lib/mysql
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       interval: 1s
       retries: 120
     ports:  
-      - 3306:3306
+      - 5001:5001
     volumes:
       - db_data:/var/lib/mysql
 


### PR DESCRIPTION
Changes the exposed port for the database in the docker-compose to 5100, to avoid conflict with the default MySQL port